### PR TITLE
feat: stop-loss carry_over 자연 설계 + UI/파이프라인 단순화

### DIFF
--- a/frontend/src/app/lab/page.tsx
+++ b/frontend/src/app/lab/page.tsx
@@ -189,7 +189,7 @@ export default function LabPage() {
   const [stopLossEnabled, setStopLossEnabled] = useState(false);
   const [stopLossPct, setStopLossPct] = useState(15);
   const [stopLossMode, setStopLossMode] = useState<'sell' | 'reduce' | 'redistribute'>('sell');
-  const [stopLossBasis, setStopLossBasis] = useState<'entry' | 'peak'>('entry');
+  const [stopLossBasis, setStopLossBasis] = useState<'entry' | 'peak'>('peak');
 
   // ─── Code ───
   const [code, setCode] = useState('');
@@ -218,9 +218,8 @@ export default function LabPage() {
   const [regimeResult, setRegimeResult] = useState<Record<string, unknown> | null>(null);
   const [regimeLoading, setRegimeLoading] = useState(false);
   const [regimeSaveMsg, setRegimeSaveMsg] = useState('');
-  const [regimeMaWindow, setRegimeMaWindow] = useState(50);
-  const [regimeMaWindowInput, setRegimeMaWindowInput] = useState('50');
-  const [regimeMode, setRegimeMode] = useState<'ma' | 'cycle' | 'ai' | 'inertia'>('ma');
+  const [regimeMaWindow] = useState(50);
+  const [regimeMode, setRegimeMode] = useState<'cycle' | 'ai'>('ai');
 
   // ─── Auto-generate strategy name ───
   const autoName = useMemo(() => {
@@ -308,11 +307,9 @@ export default function LabPage() {
         if (parsed.maRevWindow !== undefined) setMaRevWindow(parsed.maRevWindow as 120 | 250);
         if (parsed.universe) setUniverse(parsed.universe);
         if (parsed.rebalType) setRebalType(parsed.rebalType);
-        // 유니버스/리밸런싱은 전략 이름에서도 파싱
-        if (/코스피\+코스닥|KOSPI\+KOSDAQ/i.test(name)) setUniverse('KOSPI+KOSDAQ');
-        else if (/코스피|KOSPI/i.test(name)) setUniverse('KOSPI');
-        if (/격주|biweekly/i.test(name)) setRebalType('biweekly');
-        else if (/월간|monthly/i.test(name)) setRebalType('monthly');
+        // 유니버스/리밸런싱은 KOSPI/월간으로 고정 (옵션 단순화)
+        setUniverse('KOSPI');
+        setRebalType('monthly');
       }
     } catch {
       // 코드 없는 전략 (레짐 조합 등)은 무시
@@ -628,7 +625,6 @@ export default function LabPage() {
                     onChange={(e) => setUniverse(e.target.value as 'KOSPI' | 'KOSPI+KOSDAQ')}
                   >
                     <option value="KOSPI">KOSPI</option>
-                    <option value="KOSPI+KOSDAQ">KOSPI+KOSDAQ</option>
                   </select>
                 </div>
                 <div>
@@ -675,7 +671,6 @@ export default function LabPage() {
                     onChange={(e) => setRebalType(e.target.value as 'monthly' | 'biweekly')}
                   >
                     <option value="monthly">월간</option>
-                    <option value="biweekly">격주</option>
                   </select>
                 </div>
               </div>
@@ -1104,10 +1099,6 @@ export default function LabPage() {
                   <span className="text-xs text-muted font-medium">레짐 기준</span>
                   <div className="flex rounded-lg border border-border overflow-hidden text-xs">
                     <button
-                      onClick={() => setRegimeMode('ma')}
-                      className={`px-3 py-1.5 transition-colors ${regimeMode === 'ma' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
-                    >MA 기준</button>
-                    <button
                       onClick={() => setRegimeMode('cycle')}
                       className={`px-3 py-1.5 transition-colors ${regimeMode === 'cycle' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
                     >사이클 기준</button>
@@ -1115,51 +1106,19 @@ export default function LabPage() {
                       onClick={() => setRegimeMode('ai')}
                       className={`px-3 py-1.5 transition-colors ${regimeMode === 'ai' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
                     >AI 기준</button>
-                    <button
-                      onClick={() => setRegimeMode('inertia')}
-                      className={`px-3 py-1.5 transition-colors ${regimeMode === 'inertia' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
-                    >Inertia 기준</button>
                   </div>
                 </div>
-                {regimeMode === 'ma' && (
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted font-medium">MA 기간 (KOSPI 200 기준)</span>
-                    <input
-                      type="number"
-                      min={5}
-                      max={500}
-                      value={regimeMaWindowInput}
-                      onChange={(e) => setRegimeMaWindowInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          const v = parseInt(regimeMaWindowInput);
-                          if (!isNaN(v) && v >= 5 && v <= 500) setRegimeMaWindow(v);
-                        }
-                      }}
-                      onBlur={() => {
-                        const v = parseInt(regimeMaWindowInput);
-                        if (!isNaN(v) && v >= 5 && v <= 500) setRegimeMaWindow(v);
-                        else setRegimeMaWindowInput(String(regimeMaWindow));
-                      }}
-                      className="w-20 px-2 py-1 rounded border border-border bg-background text-center text-sm"
-                    />
-                    <span className="text-xs text-muted">일</span>
-                  </div>
-                )}
                 {regimeMode === 'cycle' && (
                   <span className="text-xs text-muted">고점 대비 -20% 하락 사이클 기준 (2018년 이후)</span>
                 )}
                 {regimeMode === 'ai' && (
                   <span className="text-xs text-muted">GPT-4o 멀티에이전트 월간 방향 예측</span>
                 )}
-                {regimeMode === 'inertia' && (
-                  <span className="text-xs text-muted">JM(jp=3.0) OR MA200 + Crash Overlay (10일 &lt; -5%)</span>
-                )}
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-1">
                   <label className="text-xs text-muted font-medium">
-                    {regimeMode === 'ma' ? `강세장 전략 (Bull: KOSPI 200 ≥ ${regimeMaWindow}일 MA)` : regimeMode === 'inertia' ? '강세장 전략 (Bull: JM OR MA200)' : '강세장 전략 (Bull)'}
+                    강세장 전략 (Bull)
                   </label>
                   <select
                     value={regimeBullKey}
@@ -1174,7 +1133,7 @@ export default function LabPage() {
                 </div>
                 <div className="space-y-1">
                   <label className="text-xs text-muted font-medium">
-                    {regimeMode === 'ma' ? `약세장 전략 (Bear: KOSPI 200 < ${regimeMaWindow}일 MA)` : '약세장 전략 (Bear)'}
+                    약세장 전략 (Bear)
                   </label>
                   <select
                     value={regimeBearKey}

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -7,7 +7,7 @@ Alpha Lab 일일 파이프라인 (Railway PostgreSQL)
 
 매일:
   1. Forward/Consensus     FnSpace → PG (증분)
-  2. 백테스트 캐시 갱신    4콤보 (KOSPI×월간, KOSPI×격주, KOSPI+KOSDAQ×월간, KOSPI+KOSDAQ×격주)
+  2. 백테스트 캐시 갱신    KOSPI × 월간
   3. 강건성 검증           IS/OOS + bootstrap + 롤링윈도우 → PG
 
 ※ 주가(daily_price) + 시총은 LG 그램에서 Railway PG로 별도 업로드
@@ -16,8 +16,8 @@ Alpha Lab 일일 파이프라인 (Railway PostgreSQL)
   + 마스터 스냅샷          FnSpace CompanyListApi → PG fnspace_master
   + 재무 보충              FnSpace FinanceApi → PG fnspace_finance
 
-월초 + 15일:
-  + 유니버스 재구축        PG → PG universe (biweekly 리밸런싱 대응)
+월초:
+  + 유니버스 재구축        PG → PG universe
 """
 import argparse
 import os
@@ -231,9 +231,6 @@ def step_backtest(skip_combos=None):
 
     combos = [
         ("KOSPI", "monthly"),
-        ("KOSPI", "biweekly"),
-        ("KOSPI+KOSDAQ", "monthly"),
-        ("KOSPI+KOSDAQ", "biweekly"),
     ]
 
     for universe, rebal_type in combos:
@@ -274,6 +271,8 @@ def step_custom_strategies():
         FROM backtest_cache
         WHERE strategy_code IS NOT NULL
           AND name NOT IN ('A0', 'KOSPI', '__ROBUSTNESS__')
+          AND universe = 'KOSPI'
+          AND rebal_type = 'monthly'
     """)
     rows = cur.fetchall()
     conn.close()
@@ -325,6 +324,8 @@ def step_regime_combo_strategies():
         SELECT name, results_json, universe, rebal_type
         FROM backtest_cache
         WHERE name LIKE '레짐조합_%%'
+          AND universe = 'KOSPI'
+          AND rebal_type = 'monthly'
     """)
     rows = cur.fetchall()
     conn.close()
@@ -648,7 +649,7 @@ def notify(title, message):
 # 메인
 # ═══════════════════════════════════════════════════════════
 
-def step_ai_filter(strategy_path: str = None):
+def step_ai_filter(strategy_path: str = None, calc_date: str = None):
     """AI 종목 필터: 팩터 상위 30종목 → AI 분석 → 최종 10종목."""
     from lib.ai_stock_filter import run_ai_filter
     from lib.factor_engine import score_stocks_from_strategy, load_strategy_module, code_to_module, DEFAULT_STRATEGY_CODE
@@ -656,7 +657,7 @@ def step_ai_filter(strategy_path: str = None):
 
     conn = get_conn()
     try:
-        calc_date = datetime.now().strftime("%Y-%m-%d")
+        calc_date = calc_date or datetime.now().strftime("%Y-%m-%d")
         if strategy_path:
             strategy = load_strategy_module(strategy_path)
             print(f"  전략: {strategy_path}")
@@ -689,6 +690,7 @@ def main():
     parser.add_argument("--ai-filter", action="store_true", help="AI 종목 필터 실행 (30→10종목)")
     parser.add_argument("--only-ai-filter", action="store_true", help="AI 종목 필터만 실행")
     parser.add_argument("--ai-strategy", type=str, default=None, help="AI 필터에 사용할 전략 파일 경로")
+    parser.add_argument("--ai-date", type=str, default=None, help="AI 필터 기준일 (YYYY-MM-DD)")
     args = parser.parse_args()
 
     is_monthly = args.monthly or datetime.now().day <= 3
@@ -717,7 +719,7 @@ def main():
     consensus_from = args.consensus_from or None
 
     if args.only_ai_filter:
-        run("AI 종목 필터", lambda: step_ai_filter(args.ai_strategy))
+        run("AI 종목 필터", lambda: step_ai_filter(args.ai_strategy, args.ai_date))
     elif args.only_custom:
         # 커스텀 전략 재계산 + 강건성만
         run("커스텀 전략 재계산", step_custom_strategies)
@@ -739,7 +741,8 @@ def main():
             run("TTM 계산", step_calc_ttm)
 
         # ── 유니버스 재구축 (매 실행 시) ──
-        run("유니버스 재구축", step_build_universe)
+        if not args.skip_universe:
+            run("유니버스 재구축", step_build_universe)
 
         # ── 매일 (주가/시총은 LG 그램에서 PG로 별도 업로드) ──
         run("Forward/Consensus 수집", lambda: step_collect_consensus(consensus_from))
@@ -752,7 +755,7 @@ def main():
             run("강건성 검증", step_robustness)
 
         if args.ai_filter:
-            run("AI 종목 필터", lambda: step_ai_filter(args.ai_strategy))
+            run("AI 종목 필터", lambda: step_ai_filter(args.ai_strategy, args.ai_date))
 
     # ── 요약 ──
     elapsed = time.time() - t0

--- a/scripts/step7_backtest.py
+++ b/scripts/step7_backtest.py
@@ -588,15 +588,23 @@ def run_backtest(strategy_name, stock_selector=None, rebal_type="monthly", progr
         sl_basis = BACKTEST_CONFIG.get("stop_loss_basis", "entry")
 
         if sl_enabled:
-            raw_return, sl_events, sl_carry_over = calc_portfolio_return_with_stoploss(
+            raw_return, sl_events, sl_carry_state = calc_portfolio_return_with_stoploss(
                 conn, stocks, start, end, stop_loss_pct=sl_pct, stop_loss_mode=sl_mode,
                 stop_loss_basis=sl_basis,
                 carry_over=sl_carry_state,
             )
-            sl_carry_state = sl_carry_over
         else:
-            raw_return = calc_portfolio_return(conn, stocks, start, end)
             sl_events = []
+            if sl_carry_state:
+                # 자연 설계: stop-loss 꺼진 기간(Bull)에도 peak 추적 → 다음 stop-loss 기간(Bear)에서 정확한 trailing stop
+                raw_return, _, sl_carry_state = calc_portfolio_return_with_stoploss(
+                    conn, stocks, start, end,
+                    stop_loss_pct=9999, stop_loss_mode="sell",
+                    stop_loss_basis=sl_basis,
+                    carry_over=sl_carry_state,
+                )
+            else:
+                raw_return = calc_portfolio_return(conn, stocks, start, end)
 
         if stocks:
             slip_codes = [c for c, _ in stocks]


### PR DESCRIPTION
- step7_backtest: Bull 기간에도 sl_carry_state 유지 → Bear에서 정확한 trailing stop
- lab UI: 손절 basis 기본값 'peak', 유니버스(KOSPI)/리밸런싱(monthly)/레짐(cycle+ai)으로 옵션 축소
- run_pipeline: combos 4→1, 커스텀/레짐조합 재계산 쿼리에 KOSPI/monthly 필터

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>