### PR TITLE
fix: FilterBar 빈 상태 null 반환

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -49,20 +49,20 @@ export default function FilterBar({
   className,
   children,
 }: FilterBarProps) {
+  const universeOptions = [{ value: 'KOSPI', label: 'KOSPI' }];
+  const rebalOptions = [{ value: 'monthly', label: '월간' }];
+  const hasToggles = universeOptions.length > 1 || rebalOptions.length > 1;
+  if (!hasToggles && !children) return null;
   return (
     <div className={cn('flex items-center gap-3 flex-wrap', className)}>
       <ToggleGroup
         value={universe}
-        options={[
-          { value: 'KOSPI', label: 'KOSPI' },
-        ]}
+        options={universeOptions}
         onChange={(v) => onUniverseChange(v as 'KOSPI' | 'KOSPI+KOSDAQ')}
       />
       <ToggleGroup
         value={rebalType}
-        options={[
-          { value: 'monthly', label: '월간' },
-        ]}
+        options={rebalOptions}
         onChange={(v) => onRebalTypeChange(v as 'monthly' | 'biweekly')}
       />
       {children}


### PR DESCRIPTION
토글/children 모두 없으면 wrapper div 안 그리도록 수정 → 상단 flex 레이아웃 자연스럽게