### PR TITLE
fix: fnspace_forward stock_code 'A' 접두사 추가로 F_* 팩터 정상 계산

### DIFF
--- a/lib/factor_engine.py
+++ b/lib/factor_engine.py
@@ -223,7 +223,7 @@ def prefetch_all_data(conn, use_local_cache=False):
     if "forward" not in _prefetch_cache:
         print("[PREFETCH] Loading forward...", flush=True)
         _prefetch_cache["forward"] = read_sql("""
-            SELECT stock_code, trade_date, fwd_eps, fwd_per, fwd_ebit, fwd_ebitda,
+            SELECT 'A' || stock_code AS stock_code, trade_date, fwd_eps, fwd_per, fwd_ebit, fwd_ebitda,
                    fwd_ev_ebitda, fwd_revenue, fwd_oi, fwd_ni, fwd_roe, fwd_bps
             FROM fnspace_forward
         """, conn)
@@ -644,7 +644,7 @@ def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = Non
         fwd_df = pd.DataFrame()
         if fwd_date:
             fwd_df = read_sql("""
-                SELECT stock_code, fwd_eps, fwd_per, fwd_ebit, fwd_ebitda,
+                SELECT 'A' || stock_code AS stock_code, fwd_eps, fwd_per, fwd_ebit, fwd_ebitda,
                        fwd_ev_ebitda, fwd_revenue, fwd_oi, fwd_ni, fwd_roe, fwd_bps
                 FROM fnspace_forward WHERE trade_date = ?
             """, conn, params=(fwd_date,))
@@ -658,7 +658,7 @@ def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = Non
         fwd_3m_df = pd.DataFrame()
         if fwd_date_3m:
             fwd_3m_df = read_sql(
-                "SELECT stock_code, fwd_eps as fwd_eps_3m FROM fnspace_forward WHERE trade_date=?",
+                "SELECT 'A' || stock_code AS stock_code, fwd_eps as fwd_eps_3m FROM fnspace_forward WHERE trade_date=?",
                 conn, params=(fwd_date_3m,),
             )
 


### PR DESCRIPTION
## Summary
- `alpha_lab.fnspace_forward.stock_code`는 `'A'` 접두사 없이(`075580`) 저장되어 있으나, `factor_engine`이 만드는 `merged` 프레임의 `stock_code`는 `fnspace_finance`/`fnspace_master`/`daily_price`(코드에서 `'A'` 붙임) 기준으로 모두 `A075580` 형태. 결과적으로 `fwd_df`의 left join이 **전 종목 실패** → `fwd_*` 컬럼 NaN
- 그 영향으로 `F_PER`, `F_PBR`, `F_EVEBITDA`, `F_SPSG`, `F_EPS_M`의 raw 값이 **전 기간 100% null**로 계산됨 (저장된 `backtest_cache.factor_scores_json`에서 확인). 가중치는 부여됐지만 raw가 null → score=0, contrib=0 → 실제 스코어링 무영향
- `lib/factor_engine.py` 3곳 SELECT문에 `'A' || stock_code AS stock_code` 추가하여 merge key 정합

## 영향 범위
- 모든 저장 전략이 영향. `수정전략_코스피_cap30%_top30_tx30bp_월간` 기준 가중치 약 0.40(F_PER .05 + F_EVEBITDA .05 + F_PBR .05 + F_SPSG .10 + F_EPS_M .15) 정도가 실제로는 무시되어 왔음
- ATT_PER/ATT_EVEBIT(회귀 매력도)은 별도 경로로 계산되어 정상 동작

## Test plan
- [ ] 단일 리밸 날짜에 대해 `score_stocks_from_strategy` 실행, F_PER/F_PBR raw가 채워지는지 확인
- [ ] 백테스트 캐시 재생성 후 기존 전략 성과 비교 (성과 변동 폭이 forward 컴포넌트 가중치만큼 합리적인지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)