### PR TITLE
feat: run_pipeline 백테스트 경량화 + 종목별 팩터값 검증 도구

### DIFF
--- a/analysis/backtest_forward_fix_compare.py
+++ b/analysis/backtest_forward_fix_compare.py
@@ -1,0 +1,215 @@
+"""
+analysis/backtest_forward_fix_compare.py
+
+forward fix(PR #13) 적용 효과 확인용 핀포인트 백테스트.
+A0(기본 전략)과 수정전략_코스피_cap30%_top30_tx30bp_월간 두 개만 돌려서
+지표(CAGR/MDD/Sharpe/total_return) + 최근 리밸 편입 종목을 비교한다.
+
+실행:
+  python analysis/backtest_forward_fix_compare.py                # 결과 출력만 (DB 저장 X)
+  python analysis/backtest_forward_fix_compare.py --save         # backtest_cache에 결과도 갱신
+  python analysis/backtest_forward_fix_compare.py --only 수정    # 수정전략만
+  python analysis/backtest_forward_fix_compare.py --only A0      # A0만
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+from lib.db import get_conn
+from lib.data import run_strategy_backtest, save_strategy
+from lib.factor_engine import DEFAULT_STRATEGY_CODE, clear_factor_cache, clear_prefetch_cache
+
+
+TARGETS = {
+    "A0": {
+        "code_source": "DEFAULT_STRATEGY_CODE",
+        "universe": "KOSPI",
+        "rebal_type": "monthly",
+    },
+    "수정전략_코스피_cap30%_top30_tx30bp_월간": {
+        "code_source": "DB",
+        "universe": "KOSPI",
+        "rebal_type": "monthly",
+    },
+}
+
+
+def load_strategy_code(name: str) -> str | None:
+    """A0는 DEFAULT_STRATEGY_CODE, 그 외는 backtest_cache.strategy_code에서 로드."""
+    spec = TARGETS[name]
+    if spec["code_source"] == "DEFAULT_STRATEGY_CODE":
+        return DEFAULT_STRATEGY_CODE
+    conn = get_conn()
+    raw = conn._conn.cursor() if hasattr(conn, "_conn") else conn.cursor()
+    raw.execute(
+        "SELECT strategy_code FROM alpha_lab.backtest_cache "
+        "WHERE name=%s AND universe=%s AND rebal_type=%s",
+        (name, spec["universe"], spec["rebal_type"]),
+    )
+    row = raw.fetchone()
+    conn.close()
+    if not row or not row[0]:
+        return None
+    return row[0]
+
+
+def _pick(result: dict, key: str):
+    """result["CUSTOM"][key] 또는 result[key]에서 안전하게 추출."""
+    if not isinstance(result, dict):
+        return None
+    if "CUSTOM" in result and key in result["CUSTOM"]:
+        return result["CUSTOM"][key]
+    return result.get(key)
+
+
+def _fmt_pct(v):
+    return f"{v*100:+.2f}%" if isinstance(v, (int, float)) else "n/a"
+
+
+def _fmt_num(v, prec=2):
+    return f"{v:.{prec}f}" if isinstance(v, (int, float)) else "n/a"
+
+
+def run_one(name: str) -> dict | None:
+    """단일 전략 실행."""
+    spec = TARGETS[name]
+    code = load_strategy_code(name)
+    if not code:
+        print(f"  ✗ {name}: strategy_code 못 찾음")
+        return None
+
+    print(f"\n  ▶ {name} ({spec['universe']}/{spec['rebal_type']}) 백테스트 시작")
+    clear_factor_cache()
+    clear_prefetch_cache()
+
+    result = run_strategy_backtest(
+        strategy_code=code,
+        universe=spec["universe"],
+        rebal_type=spec["rebal_type"],
+    )
+
+    if not result or "error" in result:
+        err = result.get("error") if result else "no result"
+        print(f"    ✗ 실패: {err}")
+        return None
+
+    return result
+
+
+def print_summary(name: str, result: dict):
+    """단일 전략 결과 요약."""
+    tr = _pick(result, "total_return")
+    cagr = _pick(result, "cagr")
+    mdd = _pick(result, "mdd")
+    sharpe = _pick(result, "sharpe")
+    mstd = _pick(result, "monthly_std")
+    turnover = _pick(result, "avg_turnover")
+    months = _pick(result, "months")
+    avg_size = _pick(result, "avg_portfolio_size")
+
+    print(f"\n  ── {name} ──")
+    print(f"    기간(개월):     {months}")
+    print(f"    평균 종목수:    {_fmt_num(avg_size, 1)}")
+    print(f"    총수익률:       {_fmt_pct(tr)}")
+    print(f"    CAGR:           {_fmt_pct(cagr)}")
+    print(f"    MDD:            {_fmt_pct(mdd)}")
+    print(f"    Sharpe:         {_fmt_num(sharpe, 2)}")
+    print(f"    월간 변동성:    {_fmt_pct(mstd)}")
+    print(f"    평균 회전율:    {_fmt_pct(turnover)}")
+
+
+def print_latest_holdings(name: str, result: dict, top: int = 30):
+    """가장 최근 리밸 날짜의 편입 종목과 비중."""
+    custom = result.get("CUSTOM", result) if isinstance(result, dict) else {}
+    dates = custom.get("rebalance_dates", [])
+    holdings = custom.get("holdings", None) or custom.get("holdings_by_date", None)
+    if not dates or not holdings:
+        print(f"    (holdings 정보 없음 — name={name})")
+        return
+
+    last_date = dates[-1]
+    last_holdings = holdings.get(last_date) if isinstance(holdings, dict) else None
+    if not last_holdings:
+        print(f"    (마지막 리밸 {last_date} holdings 없음)")
+        return
+
+    print(f"\n  ── {name} 최근 리밸({last_date}) 편입 종목 ──")
+    if isinstance(last_holdings, list):
+        rows = last_holdings
+    elif isinstance(last_holdings, dict):
+        rows = [{"code": k, **(v if isinstance(v, dict) else {"weight": v})}
+                for k, v in last_holdings.items()]
+    else:
+        print(f"    (holdings 형식 미지원: {type(last_holdings).__name__})")
+        return
+
+    def _w(r):
+        if not isinstance(r, dict):
+            return 0
+        return r.get("weight") or r.get("w") or 0
+
+    rows = sorted(rows, key=_w, reverse=True)[:top]
+    print(f"    {'#':>3}  {'코드':<8}  {'종목명':<20}  {'비중':>8}")
+    for i, r in enumerate(rows, 1):
+        code = r.get("code") or r.get("stock_code") or "?"
+        nm = (r.get("name") or r.get("종목명") or "")[:20]
+        w = _w(r)
+        w_str = f"{w*100:.2f}%" if isinstance(w, (int, float)) else str(w)
+        print(f"    {i:>3}  {code:<8}  {nm:<20}  {w_str:>8}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--save", action="store_true", help="backtest_cache에 결과 저장")
+    parser.add_argument("--only", type=str, default=None,
+                        choices=list(TARGETS.keys()) + [None],
+                        help="특정 전략만 실행")
+    parser.add_argument("--no-holdings", action="store_true", help="최근 holdings 출력 생략")
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("  forward fix 적용 효과 핀포인트 백테스트")
+    print("  대상: A0 + 수정전략_코스피_cap30%_top30_tx30bp_월간")
+    print("=" * 60)
+
+    targets = [args.only] if args.only else list(TARGETS.keys())
+    results = {}
+
+    for name in targets:
+        result = run_one(name)
+        if result is None:
+            continue
+        results[name] = result
+        print_summary(name, result)
+        if not args.no_holdings:
+            print_latest_holdings(name, result)
+
+        if args.save:
+            code = load_strategy_code(name)
+            spec = TARGETS[name]
+            try:
+                save_strategy(
+                    name=name,
+                    code=code,
+                    results=result,
+                    universe=spec["universe"],
+                    rebal_type=spec["rebal_type"],
+                )
+                print(f"    ✓ backtest_cache 저장 완료")
+            except Exception as e:
+                print(f"    ✗ 저장 실패: {e}")
+
+    print("\n" + "=" * 60)
+    print("  완료")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/inspect_factor_scores.py
+++ b/analysis/inspect_factor_scores.py
@@ -1,0 +1,185 @@
+"""
+analysis/inspect_factor_scores.py
+
+backtest_cache.factor_scores_json에 저장된 종목별 팩터 raw/score/weight/contrib
+값을 표 형태로 출력. 새 백테스트(`--only-backtest`) 후 어느 종목이 어떤 팩터로
+선정됐는지, F_*가 실제로 raw 값을 가지고 들어갔는지 한눈에 확인용.
+
+실행:
+  python analysis/inspect_factor_scores.py --strategy A0                                    # 최근 리밸일
+  python analysis/inspect_factor_scores.py --strategy "수정전략_코스피_cap30%_top30_tx30bp_월간"
+  python analysis/inspect_factor_scores.py --strategy A0 --date 2026-05-15
+  python analysis/inspect_factor_scores.py --strategy A0 --top 10                            # 상위 10개만
+  python analysis/inspect_factor_scores.py --strategy A0 --csv out.csv                       # CSV로 저장
+  python analysis/inspect_factor_scores.py --list                                            # 사용 가능한 전략 목록
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+from lib.db import get_conn
+
+
+def list_strategies(conn):
+    raw = conn._conn.cursor()
+    raw.execute("""
+        SELECT name, universe, rebal_type,
+               (factor_scores_json IS NOT NULL) AS has_fs,
+               updated_at
+        FROM alpha_lab.backtest_cache
+        ORDER BY (factor_scores_json IS NOT NULL) DESC, updated_at DESC
+    """)
+    rows = raw.fetchall()
+    print(f"{'전략명':<60} {'universe':<14} {'rebal':<9} {'factor_scores':<14} {'updated_at'}")
+    for name, uni, rt, has_fs, ts in rows:
+        flag = "✓" if has_fs else "✗"
+        print(f"{name[:60]:<60} {uni:<14} {rt:<9} {flag:<14} {ts}")
+
+
+def load_factor_scores(conn, name: str, universe: str, rebal_type: str):
+    raw = conn._conn.cursor()
+    raw.execute("""
+        SELECT factor_scores_json, results_json FROM alpha_lab.backtest_cache
+        WHERE name=%s AND universe=%s AND rebal_type=%s
+    """, (name, universe, rebal_type))
+    row = raw.fetchone()
+    if not row:
+        return None, None
+    fs, rj = row
+    if isinstance(fs, str): fs = json.loads(fs)
+    if isinstance(rj, str): rj = json.loads(rj)
+    return fs, rj
+
+
+def pick_date(fs: dict, date: str | None) -> str | None:
+    """최신 리밸 날짜 또는 입력 날짜."""
+    if not fs:
+        return None
+    keys = sorted(fs.keys())
+    if date:
+        if date not in fs:
+            print(f"  날짜 {date} 없음. 가능한 날짜 (마지막 5개): {keys[-5:]}")
+            return None
+        return date
+    return keys[-1]
+
+
+def print_table(rows: list, date: str, top: int):
+    """rows: [{code, name, factors:[{key,raw,score,weight,contrib}, ...]}, ...]"""
+    if not rows:
+        print("  종목 없음")
+        return
+
+    # 활성 팩터 키 추출 (weight > 0)
+    sample = rows[0]
+    factor_keys = [f["key"] for f in sample.get("factors", []) if (f.get("weight") or 0) > 0]
+    if not factor_keys:
+        factor_keys = [f["key"] for f in sample.get("factors", [])]
+
+    print(f"\n  ── 리밸일 {date} | 상위 {min(top, len(rows))}/{len(rows)}종목 ──\n")
+
+    # 헤더
+    hdr = f"{'#':>3}  {'코드':<8}  {'종목명':<14}  {'final':>7}"
+    for k in factor_keys:
+        hdr += f"  {k:>11}"
+    print(hdr)
+    print(f"  {'':>3}  {'':<8}  {'':<14}  {'':>7}", end="")
+    for _ in factor_keys:
+        print(f"  {'raw|score':>11}", end="")
+    print()
+
+    for i, r in enumerate(rows[:top], 1):
+        code = r.get("code", "?")
+        nm = (r.get("name") or "")[:14]
+        final = r.get("final_score") or sum((f.get("contrib") or 0) for f in r.get("factors", []))
+        line = f"  {i:>3}  {code:<8}  {nm:<14}  {final:>7.2f}"
+        f_map = {f["key"]: f for f in r.get("factors", [])}
+        for k in factor_keys:
+            f = f_map.get(k, {})
+            raw = f.get("raw")
+            score = f.get("score")
+            raw_str = "null" if raw is None else (f"{raw:.2f}" if isinstance(raw, (int, float)) else str(raw)[:5])
+            score_str = "-" if score is None else f"{score}"
+            line += f"  {raw_str:>6}|{score_str:<4}"
+        print(line)
+
+
+def to_csv(rows: list, date: str, path: str):
+    import csv
+    if not rows:
+        return
+    factor_keys = [f["key"] for f in rows[0].get("factors", [])]
+    fieldnames = ["rank", "code", "name", "final_score"]
+    for k in factor_keys:
+        fieldnames.extend([f"{k}_raw", f"{k}_score", f"{k}_weight", f"{k}_contrib"])
+
+    with open(path, "w", encoding="utf-8-sig", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for i, r in enumerate(rows, 1):
+            row = {
+                "rank": i,
+                "code": r.get("code", ""),
+                "name": r.get("name", ""),
+                "final_score": r.get("final_score") or sum((fc.get("contrib") or 0) for fc in r.get("factors", [])),
+            }
+            f_map = {fc["key"]: fc for fc in r.get("factors", [])}
+            for k in factor_keys:
+                fc = f_map.get(k, {})
+                row[f"{k}_raw"] = fc.get("raw")
+                row[f"{k}_score"] = fc.get("score")
+                row[f"{k}_weight"] = fc.get("weight")
+                row[f"{k}_contrib"] = fc.get("contrib")
+            w.writerow(row)
+    print(f"\n  ✓ CSV 저장: {path} (리밸일 {date}, {len(rows)}종목)")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--strategy", type=str, help="전략명 (예: 'A0' 또는 '수정전략_...')")
+    parser.add_argument("--universe", type=str, default="KOSPI")
+    parser.add_argument("--rebal-type", type=str, default="monthly")
+    parser.add_argument("--date", type=str, default=None, help="리밸 날짜 (미지정시 가장 최근)")
+    parser.add_argument("--top", type=int, default=30, help="출력 종목 수")
+    parser.add_argument("--csv", type=str, default=None, help="CSV 파일로 저장")
+    parser.add_argument("--list", action="store_true", help="저장된 전략 목록만 보기")
+    args = parser.parse_args()
+
+    conn = get_conn()
+
+    if args.list or not args.strategy:
+        list_strategies(conn)
+        return
+
+    fs, _ = load_factor_scores(conn, args.strategy, args.universe, args.rebal_type)
+    if fs is None:
+        print(f"  '{args.strategy}' 캐시 없음. --list로 확인하세요.")
+        return
+    if not fs:
+        print(f"  '{args.strategy}' 의 factor_scores_json이 비어있음. 백테스트를 다시 돌려야 합니다.")
+        return
+
+    date = pick_date(fs, args.date)
+    if not date:
+        return
+
+    rows = fs[date]
+    if not isinstance(rows, list):
+        print(f"  factor_scores[{date}] 형식이 list가 아님: {type(rows).__name__}")
+        return
+
+    print(f"\n  전략: {args.strategy} ({args.universe}/{args.rebal_type})")
+    print_table(rows, date, args.top)
+
+    if args.csv:
+        to_csv(rows, date, args.csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/verify_forward_fix.py
+++ b/analysis/verify_forward_fix.py
@@ -1,0 +1,133 @@
+"""
+analysis/verify_forward_fix.py
+
+forward fix(PR #13)가 실제로 적용되어 fwd_* 컬럼이 join되고
+F_PER / F_PBR / F_EVEBITDA / F_SPSG / F_EPS_M raw 값이 채워지는지
+**단일 리밸 날짜**에 대해 직접 검증한다 (백테스트 안 돌림, ~30초).
+
+실행:
+  python analysis/verify_forward_fix.py                # 가장 최근 리밸일
+  python analysis/verify_forward_fix.py --date 2026-05-15
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+from lib.db import get_conn
+from lib.factor_engine import load_factor_data, clear_factor_cache
+
+
+def _pct_non_null(series) -> str:
+    n = len(series)
+    if n == 0:
+        return "0/0 (-)"
+    nn = series.notna().sum()
+    return f"{nn}/{n} ({nn/n*100:.1f}%)"
+
+
+def _pct_positive(series) -> str:
+    n = len(series)
+    if n == 0:
+        return "0/0 (-)"
+    pos = ((series.notna()) & (series > 0)).sum()
+    return f"{pos}/{n} ({pos/n*100:.1f}%)"
+
+
+def get_latest_rebal_date(conn) -> str:
+    """가장 최근 KOSPI/monthly 리밸 날짜."""
+    cur = conn._conn.cursor() if hasattr(conn, "_conn") else conn.cursor()
+    cur.execute("""
+        SELECT MAX(trade_date) FROM alpha_lab.universe
+        WHERE rebal_type='monthly'
+    """)
+    return cur.fetchone()[0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", type=str, default=None, help="검증할 리밸 날짜 (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    conn = get_conn()
+    calc_date = args.date or get_latest_rebal_date(conn)
+    print(f"\n검증 날짜: {calc_date}")
+    print("=" * 60)
+
+    clear_factor_cache()
+    df = load_factor_data(conn, calc_date)
+    if df is None or df.empty:
+        print("  load_factor_data 결과 비어있음")
+        return
+
+    print(f"  load_factor_data 종목수: {len(df)}")
+    print()
+
+    # 1) fwd_* 원본 컬럼 채움률 (join이 성공했는지)
+    print("── 1단계: fnspace_forward join 성공 여부 (fwd_* 원본 컬럼) ──")
+    for col in ["fwd_eps", "fwd_bps", "fwd_ebitda", "fwd_ebit", "fwd_revenue", "fwd_eps_3m"]:
+        if col in df.columns:
+            print(f"  {col:15s}: notna {_pct_non_null(df[col])}")
+        else:
+            print(f"  {col:15s}: 컬럼 없음 (계산 안 됨)")
+
+    # 2) F_* 파생 컬럼 (실제 점수 계산에 들어가는 값)
+    print()
+    print("── 2단계: F_* 파생 팩터 raw 값 (점수 계산에 들어가는 값) ──")
+    for col in ["f_per", "f_pbr", "f_ev_ebitda", "f_ev_ebit", "f_epsg", "f_ebitg", "f_spsg", "f_eps_m"]:
+        if col in df.columns:
+            ser = df[col]
+            pos = _pct_positive(ser) if col in ("f_per", "f_pbr", "f_ev_ebitda", "f_ev_ebit") else _pct_non_null(ser)
+            label = ">0" if col in ("f_per", "f_pbr", "f_ev_ebitda", "f_ev_ebit") else "notna"
+            mean = ser[ser.notna()].mean()
+            print(f"  {col:15s}: {label} {pos}   mean={mean:.3f}" if mean == mean else f"  {col:15s}: {label} {pos}")
+        else:
+            print(f"  {col:15s}: 컬럼 없음")
+
+    # 3) 회귀 입력 컬럼 검증 (ATT_PER, ATT_EVEBIT)
+    print()
+    print("── 3단계: 회귀 입력 검증 (ATT_PER, ATT_EVEBIT) ──")
+    for x_col, y_col, name in [("f_epsg", "f_per", "fper_epsg(ATT_PER)"),
+                                ("f_ebitg", "f_ev_ebit", "fevebit_ebitg(ATT_EVEBIT)")]:
+        if x_col in df.columns and y_col in df.columns:
+            valid = ((df[x_col].notna()) & (df[y_col].notna()) &
+                     (df[x_col] > 0) & (df[y_col] > 0))
+            n_valid = valid.sum()
+            status = "회귀 가능 ✓" if n_valid >= 20 else f"회귀 불가능 (valid<20) ✗"
+            print(f"  {name:30s}: valid={n_valid}/{len(df)}  → {status}")
+        else:
+            print(f"  {name:30s}: 컬럼 없음")
+
+    # 4) 샘플 종목 (POSCO홀딩스, 삼성전자 등) raw 값 출력
+    print()
+    print("── 4단계: 샘플 종목 raw 값 ──")
+    samples = ["A005490", "A005930", "A000660", "A035420"]  # POSCO, 삼성전자, SK하이닉스, NAVER
+    cols_show = ["stock_code", "close", "eps", "fwd_eps", "t_per", "f_per", "bps", "fwd_bps", "pbr", "f_pbr"]
+    cols_avail = [c for c in cols_show if c in df.columns]
+    sub = df[df["stock_code"].isin(samples)][cols_avail]
+    if sub.empty:
+        print("  샘플 종목 없음 (universe 다를 수 있음)")
+    else:
+        print(sub.to_string(index=False))
+
+    print()
+    print("=" * 60)
+    # 최종 판정
+    has_fwd_eps = "fwd_eps" in df.columns and df["fwd_eps"].notna().sum() > 0
+    has_f_per = "f_per" in df.columns and (df["f_per"] > 0).sum() > 0
+    if has_fwd_eps and has_f_per:
+        print("  ✓ forward fix 적용됨: fwd_* join 성공 + F_* raw 값 정상 계산")
+    elif has_fwd_eps and not has_f_per:
+        print("  ⚠ fwd_* join은 성공했으나 F_* 파생 계산 어딘가 막힘 — 추가 조사 필요")
+    else:
+        print("  ✗ fwd_* 컬럼이 비어있음 → forward fix 미적용 또는 데이터 없음")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/data.py
+++ b/lib/data.py
@@ -1422,7 +1422,8 @@ def run_strategy_backtest(strategy_code: str, progress_callback=None, universe: 
                           weight_cap_pct_override: int = None, tx_cost_bp_override: int = None,
                           rebal_type: str = None,
                           stop_loss_enabled: bool = None, stop_loss_pct: int = None,
-                          stop_loss_mode: str = None, stop_loss_basis: str = None) -> dict | None:
+                          stop_loss_mode: str = None, stop_loss_basis: str = None,
+                          reuse_prefetch: bool = False) -> dict | None:
     """
     커스텀 전략 코드로 백테스트를 실행한다.
 
@@ -1634,7 +1635,8 @@ def run_strategy_backtest(strategy_code: str, progress_callback=None, universe: 
 
         return _numpy_to_python(results)
     finally:
-        clear_prefetch_cache()
+        if not reuse_prefetch:
+            clear_prefetch_cache()
         BACKTEST_CONFIG["top_n_stocks"] = orig["top_n_stocks"]
         BACKTEST_CONFIG["transaction_cost_bp"] = orig["transaction_cost_bp"]
         BACKTEST_CONFIG["weight_cap_pct"] = orig["weight_cap_pct"]

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -256,11 +256,17 @@ def step_backtest(skip_combos=None):
             _BC["rebal_type"] = orig_r
 
 
-def step_custom_strategies():
-    """저장된 커스텀 전략들을 재계산하여 PG에 업데이트"""
+def step_custom_strategies(only_names: list[str] | None = None):
+    """저장된 커스텀 전략들을 재계산하여 PG에 업데이트.
+
+    prefetch 캐시를 step 시작 시 한 번만 로드하고 모든 전략에서 재사용한다
+    (이전: 전략당 ~2분 prefetch × N개 → 현재: 1회 ~2분 + 본 백테스트).
+    """
     os.environ["DATABASE_URL"] = PG_URL
     import psycopg2
     from lib.data import run_strategy_backtest, save_strategy
+    from lib.factor_engine import prefetch_all_data, clear_prefetch_cache
+    from step7_backtest import get_db
 
     conn = psycopg2.connect(PG_URL)
     conn.cursor().execute("SET search_path TO alpha_lab, public")
@@ -283,30 +289,46 @@ def step_custom_strategies():
 
     # 레짐조합 전략은 코드가 빈 문자열이므로 제외
     rows = [(n, c, u, r) for n, c, u, r in rows if c and c.strip() and not n.startswith("레짐조합_")]
-    print(f"  커스텀 전략 {len(rows)}개 재계산 시작")
-    for name, code, universe, rebal_type in rows:
-        try:
-            print(f"    ▶ {name} ({universe}/{rebal_type})")
-            result = run_strategy_backtest(
-                strategy_code=code,
-                universe=universe,
-                rebal_type=rebal_type,
-            )
-            if result and "error" not in result:
-                save_strategy(
-                    name=name,
-                    code=code,
-                    results=result,
+    if only_names:
+        rows = [(n, c, u, r) for n, c, u, r in rows if n in only_names]
+        if not rows:
+            print(f"  --strategies 필터에 매칭되는 전략 없음: {only_names}")
+            return
+
+    print(f"  커스텀 전략 {len(rows)}개 재계산 시작 (prefetch 캐시 공유)")
+
+    # prefetch 1회만 — 모든 전략이 이 캐시를 공유
+    _pf_conn = get_db()
+    prefetch_all_data(_pf_conn)
+    _pf_conn.close()
+
+    try:
+        for name, code, universe, rebal_type in rows:
+            try:
+                print(f"    ▶ {name} ({universe}/{rebal_type})")
+                result = run_strategy_backtest(
+                    strategy_code=code,
                     universe=universe,
                     rebal_type=rebal_type,
+                    reuse_prefetch=True,
                 )
-                tr = result.get("CUSTOM", result).get("total_return", 0)
-                print(f"      ✓ 완료 (총수익률: {tr:+.1%})")
-            else:
-                err = result.get("error", "no result") if result else "no result"
-                print(f"      ✗ 실패: {err}")
-        except Exception as e:
-            print(f"      ✗ 에러: {e}")
+                if result and "error" not in result:
+                    save_strategy(
+                        name=name,
+                        code=code,
+                        results=result,
+                        universe=universe,
+                        rebal_type=rebal_type,
+                    )
+                    tr = result.get("CUSTOM", result).get("total_return", 0)
+                    print(f"      ✓ 완료 (총수익률: {tr:+.1%})")
+                else:
+                    err = result.get("error", "no result") if result else "no result"
+                    print(f"      ✗ 실패: {err}")
+            except Exception as e:
+                print(f"      ✗ 에러: {e}")
+    finally:
+        clear_prefetch_cache()
 
 
 def step_regime_combo_strategies():
@@ -691,7 +713,14 @@ def main():
     parser.add_argument("--rebuild-universe", action="store_true",
                         help="유니버스 전체 재구축 (기존 DELETE 후 처음부터). 평소엔 incremental만 돈다")
     parser.add_argument("--skip-combos", type=str, default="", help="스킵할 콤보 (예: KOSPI_monthly,KOSPI_biweekly)")
-    parser.add_argument("--only-custom", action="store_true", help="커스텀 전략 재계산+강건성만 실행")
+    parser.add_argument("--only-custom", action="store_true", help="커스텀 전략 재계산만 실행")
+    parser.add_argument("--strategies", type=str, default="",
+                        help="특정 커스텀 전략만 실행 (콤마 구분, 예: 'A0,수정전략_코스피_cap30%_top30_tx30bp_월간')")
+    parser.add_argument("--skip-regime-combo", action="store_true", help="레짐조합 전략 재계산 스킵")
+    parser.add_argument("--with-robustness", action="store_true",
+                        help="강건성 검증 포함 (기본은 스킵). --skip-robustness보다 우선.")
+    parser.add_argument("--skip-robustness", action="store_true",
+                        help="(deprecated) 기본이 스킵이라 불필요. 호환성용.")
     parser.add_argument("--consensus-from", type=str, default="", help="Forward/Consensus 수집 시작일 (YYYYMMDD, 일회성 보충용)")
     parser.add_argument("--ai-filter", action="store_true", help="AI 종목 필터 실행 (30→10종목)")
     parser.add_argument("--only-ai-filter", action="store_true", help="AI 종목 필터만 실행")
@@ -723,22 +752,31 @@ def main():
 
     skip_combos = [s.strip() for s in args.skip_combos.split(",") if s.strip()] if args.skip_combos else []
     consensus_from = args.consensus_from or None
+    only_strategies = [s.strip() for s in args.strategies.split(",") if s.strip()] if args.strategies else None
+    # 강건성: 기본 스킵, --with-robustness가 있어야 실행
+    do_robustness = args.with_robustness
 
     if args.only_ai_filter:
         run("AI 종목 필터", lambda: step_ai_filter(args.ai_strategy, args.ai_date))
     elif args.only_custom:
-        # 커스텀 전략 재계산 + 강건성만
-        run("커스텀 전략 재계산", step_custom_strategies)
-        run("레짐조합 전략 재계산", step_regime_combo_strategies)
-        run("강건성 검증", step_robustness)
+        # 커스텀 전략 재계산만
+        run("커스텀 전략 재계산", lambda: step_custom_strategies(only_strategies))
+        if not args.skip_regime_combo:
+            run("레짐조합 전략 재계산", step_regime_combo_strategies)
+        if do_robustness:
+            run("강건성 검증", step_robustness)
     elif args.only_backtest:
         # 유니버스 + 백테스트 + 커스텀만 (수집 스킵)
         if not args.skip_universe:
             run("유니버스 재구축", lambda: step_build_universe(rebuild_all=args.rebuild_universe))
-        run("백테스트", lambda: step_backtest(skip_combos=skip_combos))
-        run("커스텀 전략 재계산", step_custom_strategies)
-        run("레짐조합 전략 재계산", step_regime_combo_strategies)
-        run("강건성 검증", step_robustness)
+        # A0는 only_strategies 필터에 'A0'가 포함될 때만 (또는 필터 미지정 시 항상)
+        if not only_strategies or "A0" in only_strategies:
+            run("백테스트", lambda: step_backtest(skip_combos=skip_combos))
+        run("커스텀 전략 재계산", lambda: step_custom_strategies(only_strategies))
+        if not args.skip_regime_combo:
+            run("레짐조합 전략 재계산", step_regime_combo_strategies)
+        if do_robustness:
+            run("강건성 검증", step_robustness)
     else:
         # ── 월초: 마스터 + 재무 + TTM ──
         if is_monthly:
@@ -755,10 +793,13 @@ def main():
         run("뉴스 수집", step_collect_news)
 
         if not args.skip_backtest:
-            run("백테스트", step_backtest)
-            run("커스텀 전략 재계산", step_custom_strategies)
-            run("레짐조합 전략 재계산", step_regime_combo_strategies)
-            run("강건성 검증", step_robustness)
+            if not only_strategies or "A0" in only_strategies:
+                run("백테스트", step_backtest)
+            run("커스텀 전략 재계산", lambda: step_custom_strategies(only_strategies))
+            if not args.skip_regime_combo:
+                run("레짐조합 전략 재계산", step_regime_combo_strategies)
+            if do_robustness:
+                run("강건성 검증", step_robustness)
 
         if args.ai_filter:
             run("AI 종목 필터", lambda: step_ai_filter(args.ai_strategy, args.ai_date))


### PR DESCRIPTION
## Summary
사용자 요청 4가지를 한 PR에 묶음:
1. `run_pipeline.py` 백테스트 단계를 가볍게 (prefetch 재사용, 강건성 기본 스킵, 옵션 추가)
2. 종목별 팩터값을 한눈에 보는 조회 도구 (`analysis/inspect_factor_scores.py`)
3. forward fix 적용 여부 30초 검증 (`analysis/verify_forward_fix.py`)
4. A0 + 수정전략 핀포인트 백테스트 (`analysis/backtest_forward_fix_compare.py`)

## 주요 변경: prefetch 재사용 (가장 큰 효과)
- `step_custom_strategies`가 `prefetch_all_data`를 step 시작 시 **1회만** 호출하도록 변경.
- 기존: 커스텀 전략 N개 × prefetch ~2분 = **14분+ 그냥 prefetch에 소비**
- 변경: 1회 prefetch + 본 백테스트만 → **약 14분 절감**
- `lib/data.py:run_strategy_backtest`에 `reuse_prefetch=False` 파라미터 추가.
  True면 `finally`의 `clear_prefetch_cache` 호출 생략 → 다음 호출의 `prefetch_all_data`가 즉시 리턴.

## CLI 옵션 추가/변경
| 옵션 | 동작 |
|---|---|
| `--strategies "A0,수정전략_..."` | 특정 커스텀 전략만 실행 |
| `--skip-regime-combo` | 레짐조합 전략 재계산 스킵 |
| **`--with-robustness`** | 강건성 검증 포함 (기본 스킵) |
| `--skip-robustness` | 호환성용 no-op (기본이 스킵이라 사실상 의미 없음) |

**주의: 강건성 검증이 기본 OFF로 반전됨.** 자동화 cron이 강건성에 의존하면 `--with-robustness` 명시 필요.

## 새 분석 스크립트
- **verify_forward_fix.py** — 단일 리밸 날짜의 `fwd_*` / `F_*` / 회귀 입력 채움률 출력. PR #13 적용 효과 30초 검증.
- **inspect_factor_scores.py** — `backtest_cache.factor_scores_json`을 표로 출력. 종목별 raw/score/weight/contrib 확인 + CSV export.
- **backtest_forward_fix_compare.py** — A0 + 수정전략 두 개만 핀포인트 백테스트. forward fix 비교용.

## Test plan
- [ ] `python scripts/run_pipeline.py --only-backtest`: 강건성 자동 스킵 확인. 커스텀 전략 7개 도는 동안 prefetch 1회만 뜨는지 로그 확인
- [ ] `python scripts/run_pipeline.py --only-backtest --with-robustness`: 강건성 검증 실행되는지 확인
- [ ] `python scripts/run_pipeline.py --only-custom --strategies "A0,수정전략_..."`: 두 개만 도는지 확인
- [ ] `python analysis/verify_forward_fix.py`: 최신 리밸일 fwd_eps/f_per 채움률 99% 정도 확인
- [ ] `python analysis/inspect_factor_scores.py --list`: 캐시된 전략 목록 출력
- [ ] `python analysis/inspect_factor_scores.py --strategy A0 --top 10`: 상위 10종목 팩터 표 출력

🤖 Generated with [Claude Code](https://claude.com/claude-code)