### PR TITLE
perf: backend startup에서 prefetch 자동 실행 (첫 백테스트 prefetch 0초)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1196,8 +1196,25 @@ def health():
 
 @app.on_event("startup")
 def _warmup_cache():
-    """Pre-load results for all universe/rebal combos on startup."""
+    """Pre-load results + prefetch_all_data on startup (background)."""
     import threading
+
+    def _prefetch_warmup():
+        """prefetch_all_data 를 부팅 시 백그라운드로 실행.
+        디스크 pkl 캐시가 fresh면 ~5초, stale이면 ~30초.
+        끝나면 사용자 첫 백테스트 클릭 시 prefetch 0초로 즉시 시작."""
+        try:
+            from lib.factor_engine import prefetch_all_data
+            from step7_backtest import get_db
+            conn = get_db()
+            prefetch_all_data(conn)
+            try:
+                conn.close()
+            except Exception:
+                pass
+            print("  [warmup] prefetch_all_data 완료 — 첫 백테스트부터 빠른 응답 가능", flush=True)
+        except Exception as e:
+            print(f"  [warmup] prefetch_all_data 실패: {e}", flush=True)
 
     def _warm():
         combos = [
@@ -1214,6 +1231,8 @@ def _warmup_cache():
             except Exception as e:
                 print(f"  [warmup] {uni}/{rt} failed: {e}")
 
+    # 두 warmup을 백그라운드 스레드에서 병렬 실행
+    threading.Thread(target=_prefetch_warmup, daemon=True).start()
     threading.Thread(target=_warm, daemon=True).start()
 
 


### PR DESCRIPTION
## Summary
사용자가 첫 백테스트 클릭 시점에 prefetch가 돌게 두지 말고, **backend 부팅 시 백그라운드로 미리** 돌게 변경. 사용자 첫 백테스트는 prefetch 시간 0초.

## 변경
- `backend/main.py:_warmup_cache` 에 `_prefetch_warmup` 스레드 추가
- uvicorn 부팅 직후 daemon 스레드에서 `prefetch_all_data()` 백그라운드 실행
- 디스크 pkl 캐시 활용 (PR #16): fresh면 ~5초, stale/첫 부팅이면 ~30초
- 트래픽 받는 스레드와 분리되어 backend 응답 영향 없음

## 효과
| 시나리오 | 이전 | 이후 |
|---|---|---|
| 부팅 직후 사용자 백테스트 | prefetch ~30초 | **0초** (이미 메모리에) |
| 데이터 새로 들어온 후 첫 백테스트 | prefetch ~30초 | ~30초 (stale 무효화) |
| 같은 날 두 번째 백테스트 | 0초 | 0초 |

재배포 후 ~30초 동안은 prefetch 진행 중 → 그 사이 사용자가 백테스트 클릭하면 평소처럼 prefetch 30초 대기. 30초 후부터 0초.

## Test plan
- [ ] 머지 후 자동 재배포 → backend Logs 확인
- [ ] 부팅 시 `[PREFETCH] Loading finance...` 로그가 자동으로 뜸
- [ ] `[warmup] prefetch_all_data 완료` 메시지 확인
- [ ] 그 후 웹뷰에서 백테스트 한 번 → prefetch 시간이 0초 또는 1~2초 (메모리 슬라이스만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)