### PR TITLE
perf: score_stocks_from_strategy 내부 단계별 timing 측정

### DIFF
--- a/lib/factor_engine.py
+++ b/lib/factor_engine.py
@@ -1214,6 +1214,28 @@ def apply_quality_filter(df, filter_config):
 # 6. 종합 파이프라인
 # ═══════════════════════════════════════════════════════
 
+_SCORE_TIMING_PHASES = {
+    "load_factor_data": 0.0,
+    "quality_filter": 0.0,
+    "regressions": 0.0,
+    "scoring": 0.0,
+    "weighted": 0.0,
+    "sort_result": 0.0,
+}
+_SCORE_TIMING_CALLS = 0
+
+
+def reset_score_timing():
+    global _SCORE_TIMING_PHASES, _SCORE_TIMING_CALLS
+    _SCORE_TIMING_PHASES = {k: 0.0 for k in _SCORE_TIMING_PHASES}
+    _SCORE_TIMING_CALLS = 0
+
+
+def report_score_timing() -> dict:
+    """누적 timing 반환 (run_backtest 끝나는 시점에서 호출)."""
+    return {"phases": dict(_SCORE_TIMING_PHASES), "calls": _SCORE_TIMING_CALLS}
+
+
 def score_stocks_from_strategy(conn, calc_date, strategy, return_df: bool = False):
     """
     전략 모듈/설정에 따라 팩터 데이터 -> 퀄리티 필터 -> 회귀분석 -> 채점 -> 가중합
@@ -1229,6 +1251,8 @@ def score_stocks_from_strategy(conn, calc_date, strategy, return_df: bool = Fals
 
     strategy: ModuleType 또는 dict-like (WEIGHTS_LARGE, WEIGHTS_SMALL, ...)
     """
+    import time as _t
+    global _SCORE_TIMING_CALLS
     # 전략 설정 읽기
     weights_large = getattr(strategy, "WEIGHTS_LARGE", {})
     weights_small = getattr(strategy, "WEIGHTS_SMALL", {})
@@ -1247,7 +1271,10 @@ def score_stocks_from_strategy(conn, calc_date, strategy, return_df: bool = Fals
     top_n = params.get("top_n", 30)
     ma_rev_window = params.get("ma_reversion_window", None)
 
+    _SCORE_TIMING_CALLS += 1
+    _t0 = _t.time()
     df = load_factor_data(conn, calc_date, ma_reversion_window=ma_rev_window)
+    _SCORE_TIMING_PHASES["load_factor_data"] += _t.time() - _t0
     if df is None or df.empty:
         return []
 
@@ -1256,19 +1283,31 @@ def score_stocks_from_strategy(conn, calc_date, strategy, return_df: bool = Fals
         df = df[df["size_group"] == "large"].copy()
 
     # 퀄리티 필터 먼저 → 투자 가능 유니버스에서만 스코어링
+    _t0 = _t.time()
     df = apply_quality_filter(df, quality_filter)
     df = df[df["quality_pass"] == 1].copy()
+    _SCORE_TIMING_PHASES["quality_filter"] += _t.time() - _t0
 
     if len(df) < 10:
         return []
 
     # 파이프라인 실행 (퀄리티 통과 종목만)
+    _t0 = _t.time()
     df, _reg_info = run_regressions(df, regression_models, outlier_filters)
+    _SCORE_TIMING_PHASES["regressions"] += _t.time() - _t0
+
+    _t0 = _t.time()
     df = apply_scoring(df, scoring_rules, scoring_mode)
+    _SCORE_TIMING_PHASES["scoring"] += _t.time() - _t0
+
+    _t0 = _t.time()
     df = calc_weighted_scores(df, weights_large, weights_small, score_map, scoring_mode)
+    _SCORE_TIMING_PHASES["weighted"] += _t.time() - _t0
 
     # 점수 순 정렬
+    _t0 = _t.time()
     passed = df.nlargest(top_n * 2, "value_score")
+    _SCORE_TIMING_PHASES["sort_result"] += _t.time() - _t0
 
     # stock_code에서 'A' 접두사 제거
     result = []

--- a/scripts/step7_backtest.py
+++ b/scripts/step7_backtest.py
@@ -539,6 +539,12 @@ def run_backtest(strategy_name, stock_selector=None, rebal_type="monthly", progr
     # ── 단계별 누적 시간 측정 ──
     _t_phases = {"regime": 0.0, "selector": 0.0, "holdings": 0.0, "return": 0.0, "slip": 0.0}
     _t_loop_start = time.time()
+    # score_stocks_from_strategy 내부 timing 초기화
+    try:
+        from lib.factor_engine import reset_score_timing
+        reset_score_timing()
+    except ImportError:
+        pass
     for i in range(total_periods):
         start = rebalance_dates[i]
         end = rebalance_dates[i + 1]
@@ -667,6 +673,22 @@ def run_backtest(strategy_name, stock_selector=None, rebal_type="monthly", progr
     print(f"[TIMING]   slip(슬리피지 SQL):     {_t_phases['slip']:.2f}s  ({_t_phases['slip']/_t_loop_total*100:.0f}%)", flush=True)
     print(f"[TIMING]   regime(레짐 SQL):       {_t_phases['regime']:.2f}s  ({_t_phases['regime']/_t_loop_total*100:.0f}%)", flush=True)
     print(f"[TIMING]   other(기타/CPU):        {_t_other:.2f}s  ({_t_other/_t_loop_total*100:.0f}%)", flush=True)
+
+    # ── selector 내부 단계별 timing 출력 (selector가 큰 비중일 때 진짜 병목 식별용) ──
+    try:
+        from lib.factor_engine import report_score_timing
+        _st = report_score_timing()
+        _st_phases = _st["phases"]
+        _st_total = sum(_st_phases.values())
+        _st_calls = _st["calls"]
+        if _st_calls > 0 and _st_total > 0:
+            print(f"\n[TIMING-SELECTOR] score_stocks_from_strategy {_st_calls}회 호출, 누적 {_st_total:.2f}s", flush=True)
+            for _phase, _v in _st_phases.items():
+                _pct = _v / _st_total * 100
+                _per_call = _v / _st_calls
+                print(f"[TIMING-SELECTOR]   {_phase:18s}: {_v:7.2f}s  ({_pct:4.0f}%)  per call: {_per_call*1000:.1f}ms", flush=True)
+    except Exception as _e:
+        print(f"[TIMING-SELECTOR] 측정 실패: {_e}", flush=True)
 
     conn.close()
 


### PR DESCRIPTION
## Summary
PR #17 측정 결과 selector가 백테스트 시간의 98% 차지 확인. selector 내부 6단계를 한 단계 더 측정해서 진짜 병목 정확히 찾음.

## 변경
- \`lib/factor_engine.py\` 에 모듈 레벨 \`_SCORE_TIMING_PHASES\` dict + \`reset_score_timing()\` / \`report_score_timing()\`
- \`score_stocks_from_strategy()\` 가 매 호출마다 6단계 누적 (load_factor_data / quality_filter / regressions / scoring / weighted / sort_result)
- \`scripts/step7_backtest.py:run_backtest\` 가 루프 시작 시 reset, 종료 시 report 호출하여 \`[TIMING-SELECTOR]\` 로 출력

## 사용법
머지 후 자동 재배포 → 웹뷰에서 백테스트 한 번 → backend Logs 에서 \`[TIMING-SELECTOR]\` 6줄 확인. 가장 큰 phase가 다음 PR 타겟.

후보:
- \`load_factor_data\` 크면 → pandas 파생 계산 (f_per, f_pbr, ATT_* 등) 최적화
- \`regressions\` 크면 → scipy.stats.linregress 호출 numpy로 대체
- \`scoring\` 크면 → pandas qcut/rank 벡터화
- \`weighted\` 크면 → DataFrame 곱셈 합산 최적화

## Test plan
- [ ] 머지 후 백테스트 1회 → \`[TIMING-SELECTOR]\` 6줄 출력
- [ ] 최대 phase 식별 → 다음 PR 방향 결정

🤖 Generated with [Claude Code](https://claude.com/claude-code)