### PR TITLE
perf: load_factor_data 내부 세부 timing 측정

### DIFF
--- a/lib/factor_engine.py
+++ b/lib/factor_engine.py
@@ -774,12 +774,19 @@ def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = Non
 
     # ── 프리페치 캐시가 있으면 메모리에서 처리 ──
     if _prefetch_cache:
+        import time as _t
+        global _LOAD_TIMING_CALLS
+        _LOAD_TIMING_CALLS += 1
+        _t0 = _t.time()
         fin_df, prev_rev_df = _get_fin_for_date(calc_date)
         if fin_df.empty:
             return None
         fwd_df, fwd_3m_df = _get_fwd_for_date(calc_date)
         price_df, price_3m_df = _get_price_for_date(calc_date)
         master_df = _get_master_for_date(calc_date)
+        _LOAD_TIMING_PHASES["slice"] += _t.time() - _t0
+
+        _t0 = _t.time()
         # _ma_window already set above
         # FE_USE_MA_CACHE=1 일 때 ma/mfi 캐시 사용 (슬라이스 후 cumcount NaN 마스킹으로 기존 동작 재현)
         # OBV는 cumsum 시작점에 민감해서 캐시 시 결과 달라짐 → 기존 함수 그대로
@@ -791,6 +798,8 @@ def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = Non
             ma_rev_df = _calc_ma_reversion(_prefetch_cache["price"], calc_date, ma_window=_ma_window)
             mfi_df = _calc_mfi(_prefetch_cache["price"], calc_date)
             obv_df = _calc_obv_slope(_prefetch_cache["price"], calc_date)
+        _LOAD_TIMING_PHASES["indicators"] += _t.time() - _t0
+        _load_derived_t0 = _t.time()  # 이후 derived phase 측정용 (함수 끝에서 합산)
     else:
         # ── DB 쿼리 로직: TTM 우선, Annual fallback ──
         # TTM 데이터 조회 — calc_date 기준 적절한 TTM_XQ 하나만 선택
@@ -1159,6 +1168,13 @@ def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = Non
 
     # 캐시 저장 (날짜+유니버스 조합)
     _factor_data_cache[_cache_key] = merged.copy()
+    # derived phase timing 합산 (prefetch 경로일 때만)
+    try:
+        if '_load_derived_t0' in locals():
+            import time as _t
+            _LOAD_TIMING_PHASES["derived"] += _t.time() - _load_derived_t0
+    except Exception:
+        pass
     return merged
 
 
@@ -1410,16 +1426,31 @@ _SCORE_TIMING_PHASES = {
 }
 _SCORE_TIMING_CALLS = 0
 
+# load_factor_data 내부 세부 timing (병목 한 단계 더 측정)
+_LOAD_TIMING_PHASES = {
+    "slice": 0.0,         # _get_fin/fwd/price/master_for_date (메모리 슬라이스)
+    "indicators": 0.0,    # _calc_ma_reversion + _calc_mfi + _calc_obv_slope
+    "derived": 0.0,       # merge + 파생 변수 (f_per, ATT_*, etc.)
+}
+_LOAD_TIMING_CALLS = 0
+
 
 def reset_score_timing():
-    global _SCORE_TIMING_PHASES, _SCORE_TIMING_CALLS
+    global _SCORE_TIMING_PHASES, _SCORE_TIMING_CALLS, _LOAD_TIMING_PHASES, _LOAD_TIMING_CALLS
     _SCORE_TIMING_PHASES = {k: 0.0 for k in _SCORE_TIMING_PHASES}
     _SCORE_TIMING_CALLS = 0
+    _LOAD_TIMING_PHASES = {k: 0.0 for k in _LOAD_TIMING_PHASES}
+    _LOAD_TIMING_CALLS = 0
 
 
 def report_score_timing() -> dict:
     """누적 timing 반환 (run_backtest 끝나는 시점에서 호출)."""
-    return {"phases": dict(_SCORE_TIMING_PHASES), "calls": _SCORE_TIMING_CALLS}
+    return {
+        "phases": dict(_SCORE_TIMING_PHASES),
+        "calls": _SCORE_TIMING_CALLS,
+        "load_phases": dict(_LOAD_TIMING_PHASES),
+        "load_calls": _LOAD_TIMING_CALLS,
+    }
 
 
 def score_stocks_from_strategy(conn, calc_date, strategy, return_df: bool = False):

--- a/scripts/step7_backtest.py
+++ b/scripts/step7_backtest.py
@@ -687,6 +687,17 @@ def run_backtest(strategy_name, stock_selector=None, rebal_type="monthly", progr
                 _pct = _v / _st_total * 100
                 _per_call = _v / _st_calls
                 print(f"[TIMING-SELECTOR]   {_phase:18s}: {_v:7.2f}s  ({_pct:4.0f}%)  per call: {_per_call*1000:.1f}ms", flush=True)
+
+        # load_factor_data 내부 세부 timing
+        _ld_phases = _st.get("load_phases", {})
+        _ld_calls = _st.get("load_calls", 0)
+        _ld_total = sum(_ld_phases.values())
+        if _ld_calls > 0 and _ld_total > 0:
+            print(f"\n[TIMING-LOAD] load_factor_data 내부 {_ld_calls}회, 누적 {_ld_total:.2f}s", flush=True)
+            for _phase, _v in _ld_phases.items():
+                _pct = _v / _ld_total * 100
+                _per_call = _v / _ld_calls
+                print(f"[TIMING-LOAD]   {_phase:12s}: {_v:7.2f}s  ({_pct:4.0f}%)  per call: {_per_call*1000:.1f}ms", flush=True)
     except Exception as _e:
         print(f"[TIMING-SELECTOR] 측정 실패: {_e}", flush=True)
 


### PR DESCRIPTION
## Summary
PR #19 결과 load_factor_data 가 selector의 99% (호출당 4.26초) 차지 확인. 그 4.26초가 indicator 계산인지, 파생 변수 계산인지, 슬라이스인지 한 단계 더 측정.

## 변경
- \`lib/factor_engine.py\`: \`_LOAD_TIMING_PHASES\` 추가 (slice/indicators/derived)
- \`load_factor_data\` 안에서 3 phase 누적 측정
- \`scripts/step7_backtest.py\`: 백테스트 끝에 \`[TIMING-LOAD]\` 4줄 출력

## 사용법
머지 후 자동 재배포 → 웹뷰에서 백테스트 1회 → backend Logs에서 \`[TIMING-LOAD]\` 찾기:
\`\`\`
[TIMING-LOAD] load_factor_data 내부 98회, 누적 ~XXs
[TIMING-LOAD]   slice       : X.XXs (XX%)
[TIMING-LOAD]   indicators  : X.XXs (XX%)
[TIMING-LOAD]   derived     : X.XXs (XX%)
\`\`\`

가장 큰 phase가 진짜 병목. 그 결과로 다음 PR 방향 정확히 결정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)