### PR TITLE
feat: stock_indicators 테이블 적재 + DB SELECT 기반 indicator (8초 → 30ms)

### DIFF
--- a/analysis/verify_indicators_db.py
+++ b/analysis/verify_indicators_db.py
@@ -1,0 +1,315 @@
+"""
+analysis/verify_indicators_db.py
+
+alpha_lab.stock_indicators 테이블 기반 indicator (FE_USE_INDICATORS_DB=1)
+결과가 기존 함수와 정확히 동일한지 검증.
+
+3단계:
+1. 함수 단위 — _calc_ma_reversion / _calc_mfi 결과 동일성
+2. score_stocks 단위 — 임시 전략으로 종목 선정 동일성
+3. (--full) 전체 백테스트 결과 동일성
+
+사전 조건:
+  - alpha_lab.stock_indicators 테이블 적재 완료
+    python scripts/build_stock_indicators.py
+  - 적재 안 됐으면 1, 2단계에서 에러
+
+사용:
+  python analysis/verify_indicators_db.py
+  python analysis/verify_indicators_db.py --full
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+import pandas as pd
+import numpy as np
+
+
+TEST_STRATEGY_CODE = '''"""검증용: MA/MFI 100% 비중 (OBV 제외, DB 적재 대상 아님)."""
+
+SCORING_MODE = {"large": "quartile"}
+
+WEIGHTS_LARGE = {
+    "PRICE_MA_REV": 0.70,
+    "MFI": 0.30,
+}
+WEIGHTS_SMALL = {}
+
+REGRESSION_MODELS = []
+OUTLIER_FILTERS = {}
+
+SCORE_MAP = {
+    "PRICE_MA_REV": "price_ma_rev_score",
+    "MFI": "mfi_score",
+}
+
+SCORING_RULES = {
+    "price_ma_rev": "rule2",
+    "mfi": "rule2",
+}
+
+PARAMS = {
+    "top_n": 30,
+    "tx_cost_bp": 30,
+    "weight_cap_pct": 10,
+    "stop_loss_enabled": False,
+}
+
+QUALITY_FILTER = {
+    "exclude_spac_etf_reit": True,
+    "require_positive_oi": True,
+    "require_positive_roe": True,
+    "min_avg_volume": 500_000_000,
+}
+'''
+
+TEST_DATES = [
+    "2018-04-02",
+    "2020-04-01",
+    "2022-04-01",
+    "2024-04-01",
+    "2026-05-15",
+]
+
+
+def _check_table_exists(conn) -> bool:
+    raw = conn._conn.cursor()
+    raw.execute("""
+        SELECT COUNT(*) FROM information_schema.tables
+        WHERE table_schema='alpha_lab' AND table_name='stock_indicators'
+    """)
+    if raw.fetchone()[0] == 0:
+        return False
+    raw.execute("SELECT COUNT(*) FROM alpha_lab.stock_indicators")
+    rows = raw.fetchone()[0]
+    print(f"  alpha_lab.stock_indicators: {rows:,} rows")
+    return rows > 0
+
+
+def _load_price_cache(conn):
+    from lib.factor_engine import prefetch_all_data, _prefetch_cache
+    if "price" not in _prefetch_cache:
+        print("[setup] prefetch_all_data 호출 중...")
+        prefetch_all_data(conn)
+    return _prefetch_cache["price"]
+
+
+def step1_function_unit():
+    """1단계: ma_reversion / mfi DB 버전 vs 기존 결과 동일성."""
+    from lib.db import get_conn
+    from lib.factor_engine import (
+        _calc_ma_reversion, _calc_ma_reversion_from_db,
+        _calc_mfi, _calc_mfi_from_db,
+    )
+
+    conn = get_conn()
+
+    print("\n" + "=" * 60)
+    print("0단계: alpha_lab.stock_indicators 테이블 확인")
+    print("=" * 60)
+    if not _check_table_exists(conn):
+        print("\n  ❌ stock_indicators 테이블이 없거나 비어있음.")
+        print("  먼저 다음 명령 실행:")
+        print("    python scripts/build_stock_indicators.py")
+        return False
+
+    price = _load_price_cache(conn)
+
+    print("\n" + "=" * 60)
+    print("1단계: 함수 단위 결과 동일성 검증")
+    print("=" * 60 + "\n")
+
+    all_ok = True
+    for calc_date in TEST_DATES:
+        try:
+            old = _calc_ma_reversion(price, calc_date).sort_values("stock_code").reset_index(drop=True)
+            new = _calc_ma_reversion_from_db(conn, calc_date).sort_values("stock_code").reset_index(drop=True)
+            ma_ok = _compare_df(old, new, ["price_ma_rev", "below_ma"])
+            print(f"  {calc_date} ma_reversion : {'✅' if ma_ok else '❌'} (rows old={len(old)} new={len(new)})")
+            if not ma_ok:
+                all_ok = False
+                _diff_report(old, new, calc_date, "ma_reversion")
+
+            old = _calc_mfi(price, calc_date).sort_values("stock_code").reset_index(drop=True)
+            new = _calc_mfi_from_db(conn, calc_date).sort_values("stock_code").reset_index(drop=True)
+            mfi_ok = _compare_df(old, new, ["mfi"])
+            print(f"  {calc_date} mfi          : {'✅' if mfi_ok else '❌'} (rows old={len(old)} new={len(new)})")
+            if not mfi_ok:
+                all_ok = False
+                _diff_report(old, new, calc_date, "mfi")
+        except Exception as e:
+            print(f"  {calc_date} ❌ 오류: {e}")
+            all_ok = False
+
+    conn.close()
+    print(f"\n{'✅ 1단계 PASS' if all_ok else '❌ 1단계 FAIL'}")
+    return all_ok
+
+
+def _compare_df(old: pd.DataFrame, new: pd.DataFrame, cols: list, tol: float = 1e-6) -> bool:
+    if len(old) != len(new):
+        return False
+    if not (old["stock_code"].values == new["stock_code"].values).all():
+        return False
+    for col in cols:
+        if col not in old.columns or col not in new.columns:
+            return False
+        if pd.api.types.is_numeric_dtype(old[col]):
+            diff = (old[col].fillna(-99999) - new[col].fillna(-99999)).abs().max()
+            if diff > tol:
+                return False
+        else:
+            if not (old[col].fillna("") == new[col].fillna("")).all():
+                return False
+    return True
+
+
+def _diff_report(old: pd.DataFrame, new: pd.DataFrame, calc_date: str, name: str):
+    print(f"      차이 상세 [{calc_date} {name}]:")
+    if len(old) != len(new):
+        print(f"        rows: old={len(old)} vs new={len(new)}")
+    merged = old.merge(new, on="stock_code", suffixes=("_old", "_new"))
+    for col in old.columns:
+        if col == "stock_code" or not pd.api.types.is_numeric_dtype(old[col]):
+            continue
+        a, b = f"{col}_old", f"{col}_new"
+        if a in merged.columns and b in merged.columns:
+            merged["_diff"] = (merged[a].fillna(0) - merged[b].fillna(0)).abs()
+            top = merged.nlargest(5, "_diff")[["stock_code", a, b, "_diff"]]
+            if top["_diff"].max() > 1e-6:
+                print(f"        {col} 차이 TOP 5:")
+                print(top.to_string(index=False))
+
+
+def step2_score_stocks():
+    from lib.db import get_conn
+    from lib.factor_engine import score_stocks_from_strategy, code_to_module, clear_factor_cache, clear_indicators_db_cache
+
+    calc_date = "2024-04-01"
+    print(f"\n{'=' * 60}")
+    print(f"2단계: score_stocks_from_strategy 결과 동일성 ({calc_date})")
+    print(f"{'=' * 60}\n")
+
+    strategy = code_to_module(TEST_STRATEGY_CODE)
+    conn = get_conn()
+
+    os.environ.pop("FE_USE_INDICATORS_DB", None)
+    clear_factor_cache()
+    result_off = score_stocks_from_strategy(conn, calc_date, strategy)
+
+    os.environ["FE_USE_INDICATORS_DB"] = "1"
+    clear_factor_cache()
+    clear_indicators_db_cache()
+    result_on = score_stocks_from_strategy(conn, calc_date, strategy)
+    conn.close()
+
+    codes_off = [c for c, _ in result_off]
+    codes_on = [c for c, _ in result_on]
+    scores_off = {c: s for c, s in result_off}
+    scores_on = {c: s for c, s in result_on}
+
+    same_codes = codes_off == codes_on
+    score_diff_max = max((abs(scores_off[c] - scores_on.get(c, 0)) for c in codes_off if c in scores_on), default=0)
+
+    print(f"  종목 순서 동일: {'✅' if same_codes else '❌'}")
+    print(f"  점수 최대 차이: {score_diff_max:.6f}  {'✅' if score_diff_max < 1e-6 else '❌'}")
+    if not same_codes:
+        print(f"\n  OFF top10: {codes_off[:10]}")
+        print(f"  ON  top10: {codes_on[:10]}")
+    ok = same_codes and score_diff_max < 1e-6
+    print(f"\n{'✅ 2단계 PASS' if ok else '❌ 2단계 FAIL'}")
+    return ok
+
+
+def step3_full_backtest():
+    from lib.data import run_strategy_backtest
+    from lib.factor_engine import clear_factor_cache, clear_prefetch_cache, clear_indicators_db_cache
+
+    print(f"\n{'=' * 60}")
+    print("3단계: 전체 백테스트 OFF/ON 결과 비교 (~10분)")
+    print(f"{'=' * 60}\n")
+
+    print("  OFF 백테스트 시작...")
+    os.environ.pop("FE_USE_INDICATORS_DB", None)
+    clear_prefetch_cache()
+    clear_factor_cache()
+    r_off = run_strategy_backtest(strategy_code=TEST_STRATEGY_CODE, universe="KOSPI", rebal_type="monthly")
+    if not r_off or "error" in r_off:
+        print(f"  ❌ OFF 실패: {r_off}")
+        return False
+
+    print("  ON 백테스트 시작...")
+    os.environ["FE_USE_INDICATORS_DB"] = "1"
+    clear_prefetch_cache()
+    clear_factor_cache()
+    clear_indicators_db_cache()
+    r_on = run_strategy_backtest(strategy_code=TEST_STRATEGY_CODE, universe="KOSPI", rebal_type="monthly")
+    if not r_on or "error" in r_on:
+        print(f"  ❌ ON 실패: {r_on}")
+        return False
+
+    custom_off = r_off.get("CUSTOM", r_off)
+    custom_on = r_on.get("CUSTOM", r_on)
+    keys = ["total_return", "cagr", "mdd", "sharpe", "monthly_std", "avg_turnover"]
+    all_ok = True
+    for k in keys:
+        v_off = custom_off.get(k)
+        v_on = custom_on.get(k)
+        if v_off is None or v_on is None:
+            print(f"  {k:14s}: ⚠️  missing (off={v_off}, on={v_on})")
+            continue
+        diff = abs(v_off - v_on)
+        ok = diff < 1e-6
+        all_ok = all_ok and ok
+        print(f"  {k:14s}: off={v_off:.6f}  on={v_on:.6f}  diff={diff:.2e}  {'✅' if ok else '❌'}")
+
+    print(f"\n{'✅ 3단계 PASS' if all_ok else '❌ 3단계 FAIL'}")
+    return all_ok
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--full", action="store_true", help="3단계 전체 백테스트 (~10분)")
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("Indicators DB (alpha_lab.stock_indicators) 결과 동일성 검증")
+    print("=" * 60)
+
+    ok1 = step1_function_unit()
+    if not ok1:
+        print("\n  → 1단계 실패. 코드 수정 또는 DB 적재 다시 필요.")
+        sys.exit(1)
+
+    ok2 = step2_score_stocks()
+    ok3 = step3_full_backtest() if args.full else None
+
+    print("\n" + "=" * 60)
+    print("최종 결과")
+    print("=" * 60)
+    print(f"  1단계 함수 단위:    {'✅ PASS' if ok1 else '❌ FAIL'}")
+    print(f"  2단계 score_stocks: {'✅ PASS' if ok2 else '❌ FAIL'}")
+    if ok3 is None:
+        print(f"  3단계 전체 백테스트: ⏭  스킵 (--full 옵션으로 실행)")
+    else:
+        print(f"  3단계 전체 백테스트: {'✅ PASS' if ok3 else '❌ FAIL'}")
+
+    all_ok = ok1 and ok2 and (ok3 if ok3 is not None else True)
+    if all_ok:
+        print("\n  ✅ 검증 통과 — production 적용 안전")
+        print("     Railway 환경변수 추가: FE_USE_INDICATORS_DB=1")
+    else:
+        print("\n  ❌ 일부 검증 실패")
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1233,6 +1233,21 @@ def _warmup_cache():
                 _ensure_mfi_indicators(_prefetch_cache["price"], 14)
                 _ensure_obv_indicators(_prefetch_cache["price"], 20, 60)
                 print(f"  [warmup] MA/MFI/OBV indicator 캐시 빌드 완료 ({_t.time()-t0:.1f}s)", flush=True)
+
+            # FE_USE_INDICATORS_DB=1 일 때 stock_indicators 테이블도 미리 메모리에
+            from lib.factor_engine import _is_indicators_db_enabled, _ensure_indicators_db_cache
+            if _is_indicators_db_enabled():
+                from step7_backtest import get_db
+                conn2 = get_db()
+                try:
+                    _ensure_indicators_db_cache(conn2)
+                except Exception as _e:
+                    print(f"  [warmup] stock_indicators 로드 실패: {_e}", flush=True)
+                finally:
+                    try:
+                        conn2.close()
+                    except Exception:
+                        pass
         except Exception as e:
             print(f"  [warmup] prefetch_all_data 실패: {e}", flush=True)
 

--- a/lib/factor_engine.py
+++ b/lib/factor_engine.py
@@ -457,10 +457,96 @@ _ma_indicator_cache: dict = {}   # ma_window → DataFrame
 _mfi_indicator_cache: dict = {}  # period → DataFrame
 _obv_indicator_cache: dict = {}  # (obv_ma, momentum_window) → DataFrame
 
+# DB indicator 캐시 (FE_USE_INDICATORS_DB=1)
+_indicators_db_cache: dict = {}  # "indicators" → DataFrame (전체 alpha_lab.stock_indicators)
+
 
 def _is_ma_cache_enabled() -> bool:
     import os as _os
     return _os.environ.get("FE_USE_MA_CACHE", "0").lower() in ("1", "true", "yes")
+
+
+def _is_indicators_db_enabled() -> bool:
+    """FE_USE_INDICATORS_DB=1 → alpha_lab.stock_indicators 테이블에서 SELECT 로 MA/MFI 가져옴."""
+    import os as _os
+    return _os.environ.get("FE_USE_INDICATORS_DB", "0").lower() in ("1", "true", "yes")
+
+
+def clear_indicators_db_cache():
+    _indicators_db_cache.clear()
+
+
+def _ensure_indicators_db_cache(conn):
+    """alpha_lab.stock_indicators 전체를 메모리에 한 번 로드 (~수십 MB).
+    이후 _calc_*_from_db 가 이 DataFrame 에서 슬라이스만.
+    """
+    if "indicators" in _indicators_db_cache:
+        return _indicators_db_cache["indicators"]
+    import time as _t
+    t0 = _t.time()
+    print("[INDICATORS_DB] Loading from alpha_lab.stock_indicators ...", flush=True)
+    df = read_sql("""
+        SELECT stock_code, trade_date, ma_120, deviation_120,
+               mfi_val, pos_sum_14, neg_sum_14
+        FROM alpha_lab.stock_indicators
+        ORDER BY stock_code, trade_date
+    """, conn)
+    _indicators_db_cache["indicators"] = df
+    print(f"[INDICATORS_DB] Loaded {len(df):,} rows in {_t.time()-t0:.1f}s", flush=True)
+    return df
+
+
+def _calc_ma_reversion_from_db(conn, calc_date: str, ma_window: int = 120) -> pd.DataFrame:
+    """DB indicator 캐시 사용. 기존 _calc_ma_reversion 과 동일한 결과 보장."""
+    df = _ensure_indicators_db_cache(conn)
+    lookback_days = int((250 + ma_window) * 1.5) + 30
+    cutoff = (datetime.strptime(calc_date, "%Y-%m-%d") - timedelta(days=lookback_days)).strftime("%Y-%m-%d")
+    recent = df[(df["trade_date"] >= cutoff) & (df["trade_date"] < calc_date)].copy()
+    recent = recent.sort_values(["stock_code", "trade_date"])
+    recent["__row_idx"] = recent.groupby("stock_code").cumcount()
+    _mask = recent["__row_idx"] < (ma_window - 1)
+    recent.loc[_mask, "ma_120"] = np.nan
+    recent.loc[_mask, "deviation_120"] = np.nan
+    valid = recent[recent["ma_120"].notna()]
+    if valid.empty:
+        return pd.DataFrame(columns=["stock_code", "price_ma_rev", "below_ma"])
+    last250 = valid.groupby("stock_code").tail(250)
+    result = last250.groupby("stock_code").agg(price_ma_rev=("deviation_120", "min")).reset_index()
+    result["price_ma_rev"] = result["price_ma_rev"].abs()
+    latest = valid.groupby("stock_code").last()[["deviation_120"]].reset_index()
+    latest["below_ma"] = (latest["deviation_120"] <= 0).astype(int)
+    result = result.merge(latest[["stock_code", "below_ma"]], on="stock_code", how="left")
+    result["below_ma"] = result["below_ma"].fillna(0).astype(int)
+    return result
+
+
+def _calc_mfi_from_db(conn, calc_date: str, period: int = 14, lookback: int = 20) -> pd.DataFrame:
+    """DB indicator 캐시 사용. 기존 _calc_mfi 와 동일한 결과 보장."""
+    df = _ensure_indicators_db_cache(conn)
+    lookback_days = (period + lookback) * 2 + 30
+    cutoff = (datetime.strptime(calc_date, "%Y-%m-%d") - timedelta(days=lookback_days)).strftime("%Y-%m-%d")
+    recent = df[(df["trade_date"] >= cutoff) & (df["trade_date"] < calc_date)].copy()
+    recent = recent.sort_values(["stock_code", "trade_date"])
+    recent["__row_idx"] = recent.groupby("stock_code").cumcount()
+    _mask = recent["__row_idx"] < (period - 1)
+    recent.loc[_mask, "pos_sum_14"] = np.nan
+    recent.loc[_mask, "neg_sum_14"] = np.nan
+    recent.loc[_mask, "mfi_val"] = np.nan
+    valid = recent[recent["pos_sum_14"].notna() & recent["neg_sum_14"].notna()]
+    if valid.empty:
+        return pd.DataFrame(columns=["stock_code", "mfi"])
+    last = valid.groupby("stock_code").tail(lookback)
+    first_val = last.groupby("stock_code")["mfi_val"].first()
+    last_val = last.groupby("stock_code")["mfi_val"].last()
+    result = pd.DataFrame({
+        "stock_code": last_val.index,
+        "mfi_current": last_val.values,
+        "mfi_momentum": (last_val - first_val).values,
+    })
+    result["mfi"] = result["mfi_momentum"] + np.where(
+        result["mfi_current"] < 50, (50 - result["mfi_current"]) * 0.2, 0
+    )
+    return result[["stock_code", "mfi"]]
 
 
 def clear_indicator_cache():
@@ -788,9 +874,13 @@ def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = Non
 
         _t0 = _t.time()
         # _ma_window already set above
-        # FE_USE_MA_CACHE=1 일 때 ma/mfi 캐시 사용 (슬라이스 후 cumcount NaN 마스킹으로 기존 동작 재현)
-        # OBV는 cumsum 시작점에 민감해서 캐시 시 결과 달라짐 → 기존 함수 그대로
-        if _is_ma_cache_enabled():
+        # 우선순위: DB indicator (FE_USE_INDICATORS_DB=1) > 메모리 캐시 (FE_USE_MA_CACHE=1) > 기존
+        # OBV는 cumsum 시작점에 민감해서 항상 기존 함수
+        if _is_indicators_db_enabled():
+            ma_rev_df = _calc_ma_reversion_from_db(conn, calc_date, ma_window=_ma_window)
+            mfi_df = _calc_mfi_from_db(conn, calc_date)
+            obv_df = _calc_obv_slope(_prefetch_cache["price"], calc_date)
+        elif _is_ma_cache_enabled():
             ma_rev_df = _calc_ma_reversion_cached(_prefetch_cache["price"], calc_date, ma_window=_ma_window)
             mfi_df = _calc_mfi_cached(_prefetch_cache["price"], calc_date)
             obv_df = _calc_obv_slope(_prefetch_cache["price"], calc_date)

--- a/scripts/build_stock_indicators.py
+++ b/scripts/build_stock_indicators.py
@@ -1,0 +1,174 @@
+"""
+scripts/build_stock_indicators.py
+
+종목별 일별 기술적 지표(MA, MFI 등)를 미리 계산해서 alpha_lab.stock_indicators
+테이블에 적재. backend가 매 calc_date 호출마다 rolling 계산을 반복하는 대신
+DB에서 SELECT 만으로 가져와 사용 → 백테스트 시간 큰 폭 단축.
+
+적재 항목:
+- ma_120: 120일 이동평균
+- deviation_120: (close - ma_120) / ma_120 * 100
+- mfi_val: 14일 Money Flow Index
+- pos_sum_14, neg_sum_14: MFI 계산용 중간값 (재계산 가능하지만 저장하면 빠름)
+
+OBV는 cumsum 시작점에 민감하므로 일단 캐시 제외 (기존 함수 사용).
+
+실행:
+  python scripts/build_stock_indicators.py             # 전체 재계산 (~5~10분)
+  python scripts/build_stock_indicators.py --since 2025-01-01  # 그 이후만
+"""
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+import numpy as np
+import pandas as pd
+
+from lib.db import get_conn, read_sql
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS alpha_lab.stock_indicators (
+    stock_code      TEXT NOT NULL,
+    trade_date      TEXT NOT NULL,
+    ma_120          REAL,
+    deviation_120   REAL,
+    mfi_val         REAL,
+    pos_sum_14      REAL,
+    neg_sum_14      REAL,
+    updated_at      TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (stock_code, trade_date)
+);
+CREATE INDEX IF NOT EXISTS idx_stock_indicators_date
+    ON alpha_lab.stock_indicators(trade_date);
+"""
+
+
+def ensure_schema(conn):
+    raw = conn._conn.cursor() if hasattr(conn, "_conn") else conn.cursor()
+    for stmt in SCHEMA.strip().split(";"):
+        if stmt.strip():
+            raw.execute(stmt)
+    conn.commit()
+    print("✓ schema ready")
+
+
+def fetch_price(conn, since: str | None = None) -> pd.DataFrame:
+    """daily_price 전체(또는 since 이후) 데이터를 읽음.
+    Returns: stock_code(with 'A' prefix), trade_date, close, high, low, volume
+    """
+    raw = conn._conn.cursor()
+    if since:
+        raw.execute("""
+            SELECT 'A' || stock_code AS stock_code, trade_date,
+                   close, high, low, volume
+            FROM alpha_lab.daily_price
+            WHERE trade_date >= %s
+            ORDER BY stock_code, trade_date
+        """, (since,))
+    else:
+        raw.execute("""
+            SELECT 'A' || stock_code AS stock_code, trade_date,
+                   close, high, low, volume
+            FROM alpha_lab.daily_price
+            ORDER BY stock_code, trade_date
+        """)
+    rows = raw.fetchall()
+    cols = [d[0] for d in raw.description]
+    return pd.DataFrame(rows, columns=cols)
+
+
+def compute_indicators(price: pd.DataFrame, ma_window: int = 120, mfi_period: int = 14) -> pd.DataFrame:
+    """daily_price → ma_120, deviation_120, mfi_val, pos_sum_14, neg_sum_14"""
+    df = price.sort_values(["stock_code", "trade_date"]).copy()
+
+    # MA
+    df["ma_120"] = df.groupby("stock_code")["close"].transform(
+        lambda x: x.rolling(ma_window, min_periods=ma_window).mean()
+    )
+    df["deviation_120"] = (df["close"] - df["ma_120"]) / df["ma_120"] * 100
+
+    # MFI 중간값
+    df["tp"] = (df["high"] + df["low"] + df["close"]) / 3
+    df["mf"] = df["tp"] * df["volume"]
+    tp_diff = df.groupby("stock_code")["tp"].transform(lambda x: x.diff())
+    df["pos_mf"] = np.where(tp_diff > 0, df["mf"], 0.0)
+    df["neg_mf"] = np.where(tp_diff < 0, df["mf"], 0.0)
+    df["pos_sum_14"] = df.groupby("stock_code")["pos_mf"].transform(
+        lambda x: x.rolling(mfi_period, min_periods=mfi_period).sum()
+    )
+    df["neg_sum_14"] = df.groupby("stock_code")["neg_mf"].transform(
+        lambda x: x.rolling(mfi_period, min_periods=mfi_period).sum()
+    )
+    mfr = df["pos_sum_14"] / df["neg_sum_14"].replace(0, np.nan)
+    df["mfi_val"] = 100 - (100 / (1 + mfr))
+
+    return df[["stock_code", "trade_date", "ma_120", "deviation_120",
+               "mfi_val", "pos_sum_14", "neg_sum_14"]]
+
+
+def upsert(conn, df: pd.DataFrame, batch_size: int = 5000):
+    """UPSERT (INSERT ... ON CONFLICT DO UPDATE)."""
+    raw = conn._conn.cursor()
+    cols = ["stock_code", "trade_date", "ma_120", "deviation_120",
+            "mfi_val", "pos_sum_14", "neg_sum_14"]
+    placeholders = ", ".join(["%s"] * len(cols))
+    update_cols = ", ".join(f"{c}=EXCLUDED.{c}" for c in cols if c not in ("stock_code", "trade_date"))
+    sql = f"""
+        INSERT INTO alpha_lab.stock_indicators ({", ".join(cols)})
+        VALUES ({placeholders})
+        ON CONFLICT (stock_code, trade_date)
+        DO UPDATE SET {update_cols}, updated_at = NOW()
+    """
+    total = len(df)
+    for i in range(0, total, batch_size):
+        chunk = df.iloc[i:i+batch_size]
+        rows = [
+            tuple(None if pd.isna(v) else v for v in row)
+            for row in chunk[cols].itertuples(index=False, name=None)
+        ]
+        raw.executemany(sql, rows)
+        conn.commit()
+        print(f"  ... upserted {min(i+batch_size, total)}/{total}", flush=True)
+    print(f"✓ upserted {total} rows")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--since", type=str, default=None,
+                        help="이 날짜 이후 데이터만 재계산 (incremental). 미지정시 전체.")
+    args = parser.parse_args()
+
+    t0 = time.time()
+    print("=" * 60)
+    print(f"  Stock Indicators 적재 — since={args.since or '전체'}")
+    print("=" * 60)
+
+    conn = get_conn()
+    ensure_schema(conn)
+
+    print("\n[1/3] daily_price 읽는 중...")
+    price = fetch_price(conn, since=args.since)
+    print(f"  → {len(price):,} rows, {price['stock_code'].nunique()} 종목")
+
+    print("\n[2/3] indicator 계산 중...")
+    t1 = time.time()
+    ind = compute_indicators(price)
+    print(f"  → {len(ind):,} rows ({time.time()-t1:.1f}s)")
+
+    print("\n[3/3] DB UPSERT 중...")
+    upsert(conn, ind)
+
+    conn.close()
+    print(f"\n완료 ({time.time()-t0:.1f}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -658,6 +658,22 @@ def step_calc_ttm():
     calc_ttm()
 
 
+def step_build_stock_indicators(incremental: bool = False):
+    """daily_price → MA/MFI indicator 미리 계산해서 alpha_lab.stock_indicators 적재.
+    이러면 backend가 매 calc_date에 rolling 계산 안 함 (DB SELECT만).
+
+    incremental=True 면 최근 60일치만 재계산 (rolling window 안전 여유 포함).
+    """
+    import subprocess
+    args = [sys.executable, str(Path(__file__).parent / "build_stock_indicators.py")]
+    if incremental:
+        # 최근 60영업일 재계산 (rolling 120 안전 여유)
+        from datetime import datetime as _dt, timedelta as _td
+        since = (_dt.now() - _td(days=200)).strftime("%Y-%m-%d")
+        args += ["--since", since]
+    subprocess.run(args, check=True)
+
+
 # ═══════════════════════════════════════════════════════════
 # 월초: 유니버스 재구축
 # ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
백테스트 [TIMING-LOAD] 측정 결과 indicators(MA+MFI+OBV)가 load_factor_data 호출당 7.18초 차지 (85%). 매 calc_date에 250영업일×2700종목 rolling 반복이 원인. 한 번 미리 계산해서 DB에 적재 → 매 호출 SELECT만으로 처리.

## 변경
1. \`scripts/build_stock_indicators.py\` — 신규. daily_price → ma_120, deviation_120, mfi_val 계산 후 \`alpha_lab.stock_indicators\` 에 UPSERT
2. \`lib/factor_engine.py\` — \`FE_USE_INDICATORS_DB=1\` 시 \`_calc_ma_reversion_from_db\` / \`_calc_mfi_from_db\` 호출 (메모리 캐시된 DB 데이터에서 슬라이스)
3. \`backend/main.py\` — startup 시 stock_indicators 메모리에 eager 로드
4. \`scripts/run_pipeline.py\` — step_build_stock_indicators 함수 추가 (메인 흐름 통합은 후속)
5. \`analysis/verify_indicators_db.py\` — 3단계 자동 검증

## 효과 (예상)
| | 현재 | 이후 |
|---|---|---|
| indicators per call | 7.18초 | ~30ms |
| 총 백테스트 | 14분 | ~3분 |

OBV는 cumsum 시작점 민감으로 캐시 제외 (기존 함수 유지). slice 121초도 별도 PR.

## 사용 절차 (사용자)

\`\`\`bash
# 1. 로컬에서 한 번 적재 (~5~10분)
python scripts/build_stock_indicators.py

# 2. 검증
python analysis/verify_indicators_db.py

# 3. PASS면 Railway 환경변수 FE_USE_INDICATORS_DB=1 추가
\`\`\`

## 안전
- 옵션 OFF 디폴트 → production 영향 0
- 검증 통과 후 환경변수 켜기

🤖 Generated with [Claude Code](https://claude.com/claude-code)