### PR TITLE
feat: run_pipeline 일일 파이프라인에 stock_indicators 자동 적재

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -820,6 +820,10 @@ def main():
         run("Forward/Consensus 수집", lambda: step_collect_consensus(consensus_from))
         run("뉴스 수집", step_collect_news)
 
+        # daily_price 갱신 후 stock_indicators (MA/MFI) 도 같이 적재 → 백테스트에서 사용
+        # incremental=True: 최근 200일치만 재계산 (rolling 120 lookback 안전 여유)
+        run("Stock Indicators 적재", lambda: step_build_stock_indicators(incremental=True))
+
         if not args.skip_backtest:
             if not only_strategies or "A0" in only_strategies:
                 run("백테스트", step_backtest)


### PR DESCRIPTION
## Summary
PR #22 로 stock_indicators 테이블 + 적재 스크립트 만들었지만 자동 갱신 안 됨.
사용자가 매번 run_pipeline 돌릴 때 같이 자동 갱신되도록 통합.

## 변경
\`scripts/run_pipeline.py\` 일일 파이프라인 (기본 흐름):
\`\`\`
Forward/Consensus 수집
뉴스 수집
🆕 Stock Indicators 적재 (incremental)   ← 추가
백테스트
\`\`\`

## 적재 모드
- 첫 실행: 사용자가 수동 \`python scripts/build_stock_indicators.py\` (전체 ~15~25분)
- 이후 매 run_pipeline: incremental=True 로 최근 200일치만 (~수십초~수분)

## 영향 없는 분기
- \`--only-backtest\`: 수집 스킵이라 daily_price 변동 없음 → indicator 재계산 불필요
- \`--only-custom\`: 동일

## Test plan
- [ ] PR #22 머지 + stock_indicators 적재 완료 후 적용
- [ ] \`python scripts/run_pipeline.py --monthly\` 실행 → \"Stock Indicators 적재\" step 로그 확인
- [ ] backend Logs 에서 max_trade_date 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)