### PR TITLE
perf: prefetch date 인덱스 미리 빌드 + searchsorted slice (1223x 향상)

### DIFF
--- a/analysis/profile_slice.py
+++ b/analysis/profile_slice.py
@@ -1,0 +1,258 @@
+"""analysis/profile_slice.py
+
+slice 최적화 (prefetch date 인덱스 미리 계산) PoC.
+
+- 옛 로직 (매 호출 unique() + sort + boolean indexing) vs 새 로직 (searchsorted + iloc)
+- 호출 시간 비교 (price/forward/master)
+- 결과 동일성 검증
+- 메모리 추가 사용량 측정
+
+사용:
+    python analysis/profile_slice.py
+    python analysis/profile_slice.py --calc-date 2024-12-01 --repeat 10
+
+주의:
+- Railway PG 에 접속 (.env 의 DATABASE_URL)
+- prefetch_all_data 가 disk cache 사용 (있으면 빠름)
+"""
+import argparse
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+import numpy as np
+import pandas as pd
+
+try:
+    import psutil
+    _HAS_PSUTIL = True
+except ImportError:
+    _HAS_PSUTIL = False
+
+from lib.db import get_conn
+from lib.factor_engine import (
+    prefetch_all_data,
+    _prefetch_cache,
+    _get_price_for_date,
+    _get_fwd_for_date,
+    _get_master_for_date,
+)
+
+
+def mem_mb() -> float:
+    if not _HAS_PSUTIL:
+        return -1.0
+    return psutil.Process().memory_info().rss / 1024 / 1024
+
+
+# ═══════════════════════════════════════════════════════
+# 옛 로직 (PR #25 시점) — 비교용 인라인 복사
+# ═══════════════════════════════════════════════════════
+
+def old_get_price(calc_date: str):
+    price_all = _prefetch_cache["price"]
+    dates = price_all["trade_date"].unique()
+    dates_before = sorted(d for d in dates if d < calc_date)
+    price_date = dates_before[-1] if dates_before else None
+    price_df = (
+        price_all[price_all["trade_date"] == price_date][
+            ["stock_code", "close", "market_cap", "trade_amount"]
+        ]
+        if price_date else pd.DataFrame()
+    )
+    three_m_ago = (datetime.strptime(calc_date, "%Y-%m-%d") - timedelta(days=90)).strftime("%Y-%m-%d")
+    dates_3m = sorted(d for d in dates if d <= three_m_ago)
+    price_date_3m = dates_3m[-1] if dates_3m else None
+    price_3m_df = pd.DataFrame()
+    if price_date_3m:
+        price_3m_df = price_all[price_all["trade_date"] == price_date_3m][
+            ["stock_code", "close"]
+        ].copy()
+        price_3m_df = price_3m_df.rename(columns={"close": "close_3m"})
+    return price_df, price_3m_df
+
+
+def old_get_fwd(calc_date: str):
+    fwd_all = _prefetch_cache["forward"]
+    dates = fwd_all["trade_date"].unique()
+    dates_before = sorted(d for d in dates if d < calc_date)
+    fwd_date = dates_before[-1] if dates_before else (sorted(dates)[0] if len(dates) else None)
+    fwd_df = (
+        fwd_all[fwd_all["trade_date"] == fwd_date].drop(columns=["trade_date"])
+        if fwd_date else pd.DataFrame()
+    )
+    three_m_ago = (datetime.strptime(calc_date, "%Y-%m-%d") - timedelta(days=90)).strftime("%Y-%m-%d")
+    dates_3m = sorted(d for d in dates if d <= three_m_ago)
+    fwd_date_3m = dates_3m[-1] if dates_3m else None
+    fwd_3m_df = pd.DataFrame()
+    if fwd_date_3m:
+        fwd_3m_df = fwd_all[fwd_all["trade_date"] == fwd_date_3m][["stock_code", "fwd_eps"]].copy()
+        fwd_3m_df = fwd_3m_df.rename(columns={"fwd_eps": "fwd_eps_3m"})
+    return fwd_df, fwd_3m_df
+
+
+def old_get_master(calc_date: str):
+    master_all = _prefetch_cache["master"]
+    snap_month = calc_date[:7]
+    snaps = sorted(master_all["snapshot_date"].unique())
+    valid_snaps = [s for s in snaps if s <= snap_month]
+    snap = valid_snaps[-1] if valid_snaps else (snaps[0] if snaps else snap_month)
+    return master_all[master_all["snapshot_date"] == snap][
+        ["stock_code", "stock_name", "market", "sec_cd_nm", "finacc_typ"]
+    ]
+
+
+# ═══════════════════════════════════════════════════════
+# 측정 유틸
+# ═══════════════════════════════════════════════════════
+
+def time_fn(fn, args, repeat: int) -> list[float]:
+    times = []
+    for _ in range(repeat):
+        t = time.time()
+        fn(*args)
+        times.append(time.time() - t)
+    return times
+
+
+def fmt(times):
+    arr = np.array(times) * 1000
+    return f"avg {arr.mean():7.1f}ms, min {arr.min():7.1f}ms, max {arr.max():7.1f}ms"
+
+
+def df_equal(a: pd.DataFrame, b: pd.DataFrame, key_col: str = "stock_code") -> tuple[bool, str]:
+    """동일성 검사. (정렬 무관, 인덱스 무관) — key_col 기준 정렬 후 값 비교."""
+    if len(a) != len(b):
+        return False, f"length 다름: {len(a)} vs {len(b)}"
+    if set(a.columns) != set(b.columns):
+        return False, f"컬럼 다름: {sorted(a.columns)} vs {sorted(b.columns)}"
+    a_sorted = a.sort_values(key_col).reset_index(drop=True)
+    b_sorted = b.sort_values(key_col).reset_index(drop=True)
+    try:
+        pd.testing.assert_frame_equal(a_sorted, b_sorted, check_dtype=False, check_like=True)
+        return True, "동일"
+    except AssertionError as e:
+        return False, str(e).split("\n")[0][:120]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--calc-date", default="2024-12-01")
+    ap.add_argument("--repeat", type=int, default=10,
+                    help="호출 반복 횟수 (warm-up 1 추가)")
+    args = ap.parse_args()
+
+    print("=" * 70)
+    print(f"  Profile slice  calc_date={args.calc_date}  repeat={args.repeat}")
+    print("=" * 70)
+
+    mem0 = mem_mb()
+    if mem0 >= 0:
+        print(f"\nMemory baseline: {mem0:.0f} MB")
+
+    conn = get_conn()
+
+    print("\n[1] prefetch_all_data — 캐시 로딩 + date 인덱스 빌드")
+    t0 = time.time()
+    prefetch_all_data(conn, use_local_cache=True)
+    print(f"  total: {time.time()-t0:.1f}s")
+    mem1 = mem_mb()
+    if mem1 >= 0:
+        print(f"  memory: {mem1:.0f} MB  (+{mem1-mem0:.0f} MB vs baseline)")
+
+    # 인덱스 캐시 확인
+    print("\n  date 인덱스 확인:")
+    for name in ("price", "forward", "master"):
+        ud = _prefetch_cache.get(f"_{name}_unique_dates")
+        if ud is not None:
+            print(f"    {name}: unique dates {len(ud)}, "
+                  f"date_ranges {len(_prefetch_cache.get(f'_{name}_date_ranges', {}))} entries")
+        else:
+            print(f"    {name}: 인덱스 미생성")
+
+    # ──── [2] 호출 시간 비교 ────
+    print(f"\n[2] 호출 시간 비교 (warm-up 1회 + 측정 {args.repeat}회)\n")
+
+    # warm-up
+    old_get_price(args.calc_date)
+    old_get_fwd(args.calc_date)
+    old_get_master(args.calc_date)
+    _get_price_for_date(args.calc_date)
+    _get_fwd_for_date(args.calc_date)
+    _get_master_for_date(args.calc_date)
+
+    # 측정
+    funcs = [
+        ("price",   old_get_price,      _get_price_for_date),
+        ("forward", old_get_fwd,        _get_fwd_for_date),
+        ("master",  old_get_master,     _get_master_for_date),
+    ]
+    results = []
+    for name, old_fn, new_fn in funcs:
+        old_times = time_fn(old_fn, (args.calc_date,), args.repeat)
+        new_times = time_fn(new_fn, (args.calc_date,), args.repeat)
+        old_avg = np.mean(old_times) * 1000
+        new_avg = np.mean(new_times) * 1000
+        speedup = old_avg / new_avg if new_avg > 0 else float("inf")
+        print(f"  [{name:7}]  옛: {fmt(old_times)}")
+        print(f"             새: {fmt(new_times)}")
+        print(f"             속도 향상: {speedup:.1f}x\n")
+        results.append((name, old_avg, new_avg, speedup))
+
+    # ──── [3] 결과 동일성 검증 ────
+    print("[3] 결과 동일성 검증")
+    # price: tuple (df, df_3m)
+    op = old_get_price(args.calc_date)
+    np_ = _get_price_for_date(args.calc_date)
+    ok1, msg1 = df_equal(op[0], np_[0])
+    ok2, msg2 = df_equal(op[1], np_[1]) if not op[1].empty or not np_[1].empty else (True, "둘 다 empty")
+    print(f"  price       df : {'OK' if ok1 else 'DIFF'} ({msg1})")
+    print(f"  price_3m    df : {'OK' if ok2 else 'DIFF'} ({msg2})")
+
+    of = old_get_fwd(args.calc_date)
+    nf = _get_fwd_for_date(args.calc_date)
+    ok3, msg3 = df_equal(of[0], nf[0])
+    ok4, msg4 = df_equal(of[1], nf[1]) if not of[1].empty or not nf[1].empty else (True, "둘 다 empty")
+    print(f"  forward     df : {'OK' if ok3 else 'DIFF'} ({msg3})")
+    print(f"  forward_3m  df : {'OK' if ok4 else 'DIFF'} ({msg4})")
+
+    om = old_get_master(args.calc_date)
+    nm = _get_master_for_date(args.calc_date)
+    ok5, msg5 = df_equal(om, nm)
+    print(f"  master      df : {'OK' if ok5 else 'DIFF'} ({msg5})")
+
+    # ──── [4] 요약 ────
+    print("\n" + "=" * 70)
+    print("  요약")
+    print("=" * 70)
+    total_old = sum(r[1] for r in results)
+    total_new = sum(r[2] for r in results)
+    speedup_total = total_old / total_new if total_new > 0 else float("inf")
+    print(f"\n호출당 합계 (3개 함수):")
+    print(f"  옛:  {total_old:7.1f}ms")
+    print(f"  새:  {total_new:7.1f}ms")
+    print(f"  속도 향상: {speedup_total:.1f}x")
+
+    print(f"\n예상 누적 (98회 리밸):")
+    print(f"  옛:  {total_old * 98 / 1000:.1f}s")
+    print(f"  새:  {total_new * 98 / 1000:.1f}s")
+    print(f"  절감: {(total_old - total_new) * 98 / 1000:.1f}s")
+
+    if mem1 >= 0:
+        print(f"\n메모리 (slice 인덱스 추가 부담):")
+        print(f"  baseline + cache: +{mem1 - mem0:.0f}MB")
+        print(f"  (date 인덱스 자체는 ~수 MB 수준 — 별도 측정 어려움)")
+
+    all_ok = ok1 and ok2 and ok3 and ok4 and ok5
+    print(f"\n결과 동일성: {'✅ 모두 OK' if all_ok else '❌ 차이 발견'}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/factor_engine.py
+++ b/lib/factor_engine.py
@@ -238,10 +238,15 @@ def prefetch_all_data(conn, use_local_cache=True):
             print(f"[PREFETCH] {key} loaded from disk cache", flush=True)
         if db_max_trade_date:
             _prefetch_cache["_max_trade_date"] = db_max_trade_date
+        # slice 최적화: disk cache 경로에서도 date 인덱스 빌드
+        _build_date_indices()
         print(f"[PREFETCH] All from disk cache in {time.time()-t0:.1f}s (max_trade_date={db_max_trade_date})", flush=True)
         return
     # 메모리 캐시가 이미 있고 stale 아닌 경우 → 그대로 사용
     if _prefetch_cache and all(k in _prefetch_cache for k in tables):
+        # 인덱스만 누락된 경우 (이전 버전 메모리 캐시) 빌드
+        if "_price_unique_dates" not in _prefetch_cache:
+            _build_date_indices()
         return
 
     # 강제 갱신 또는 stale → 디스크 pkl 제거하고 처음부터 DB에서 로드
@@ -328,7 +333,54 @@ def prefetch_all_data(conn, use_local_cache=True):
     # MA/MFI/OBV 인디케이터 캐시도 무효화 (price 데이터가 새로 로드됐으므로)
     clear_indicator_cache()
 
+    # ── slice 최적화: trade_date / snapshot_date 별 슬라이스 인덱스 미리 계산 ──
+    # 매 _get_*_for_date 호출에서 unique() + sort + boolean indexing on 6M rows 반복 제거.
+    # 대신 unique dates(searchsorted) + iloc(O(1) range) 으로 lookup.
+    _build_date_indices()
+
     print(f"[PREFETCH] Loaded all data in {time.time()-t0:.1f}s (max_trade_date={db_max_trade_date})", flush=True)
+
+
+def _build_date_indices():
+    """price/forward/master 의 date 컬럼별 (start, end) 인덱스 dict 미리 계산.
+    이후 _get_*_for_date 가 boolean indexing 대신 iloc 슬라이스로 처리.
+    """
+    import time as _t
+    _t0 = _t.time()
+
+    # (cache key, dataframe key, date column) 조합
+    _specs = [
+        ("price", "price", "trade_date"),
+        ("forward", "forward", "trade_date"),
+        ("master", "master", "snapshot_date"),
+    ]
+    for _name, _df_key, _date_col in _specs:
+        if _df_key not in _prefetch_cache:
+            continue
+        _df = _prefetch_cache[_df_key]
+        if _date_col not in _df.columns or len(_df) == 0:
+            continue
+        # 정렬 (이미 정렬돼 있으면 변경 없음)
+        _df = _df.sort_values(_date_col, kind="stable").reset_index(drop=True)
+        _prefetch_cache[_df_key] = _df
+        _dates_arr = _df[_date_col].values
+        # date 경계 (변경 지점) 찾기
+        if len(_dates_arr) <= 1:
+            _unique_dates = _dates_arr.copy()
+            _date_ranges = {d: (0, len(_dates_arr)) for d in _unique_dates}
+        else:
+            _boundaries = np.where(_dates_arr[1:] != _dates_arr[:-1])[0] + 1
+            _starts = np.concatenate(([0], _boundaries))
+            _ends = np.concatenate((_boundaries, [len(_dates_arr)]))
+            _unique_dates = _dates_arr[_starts]
+            _date_ranges = {
+                d: (int(s), int(e))
+                for d, s, e in zip(_unique_dates, _starts, _ends)
+            }
+        _prefetch_cache[f"_{_name}_unique_dates"] = _unique_dates
+        _prefetch_cache[f"_{_name}_date_ranges"] = _date_ranges
+
+    print(f"[PREFETCH] date indices built in {_t.time()-_t0:.1f}s", flush=True)
 
 
 def clear_prefetch_cache():
@@ -412,38 +464,79 @@ def _get_fin_for_date(calc_date: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     return fin_df, prev_rev
 
 
+def _fast_slice_by_date(name: str, df_key: str, target_date: str,
+                        strict_less: bool, fallback_first: bool = False):
+    """date 인덱스 캐시를 사용해 iloc 으로 빠른 슬라이싱.
+
+    Args:
+        name: cache 접두사 (price/forward/master)
+        df_key: _prefetch_cache 의 DataFrame 키
+        target_date: 기준 날짜 문자열
+        strict_less: True 면 target_date 미만, False 면 이하
+        fallback_first: 후보 없을 때 첫 번째 날짜로 fallback (forward 만 사용)
+
+    Returns:
+        (df_slice, picked_date) — 데이터 없으면 (None, None)
+    """
+    df = _prefetch_cache.get(df_key)
+    if df is None or len(df) == 0:
+        return None, None
+    unique_dates = _prefetch_cache.get(f"_{name}_unique_dates")
+    date_ranges = _prefetch_cache.get(f"_{name}_date_ranges")
+    if unique_dates is None or date_ranges is None:
+        # Fallback: 캐시 미빌드 시 옛 방식
+        all_dates = sorted(df[df.columns[df.columns.get_loc("trade_date" if "trade_date" in df.columns else "snapshot_date")]].unique())
+        if strict_less:
+            cand = [d for d in all_dates if d < target_date]
+        else:
+            cand = [d for d in all_dates if d <= target_date]
+        picked = cand[-1] if cand else (all_dates[0] if fallback_first and all_dates else None)
+        if picked is None:
+            return None, None
+        _date_col = "trade_date" if "trade_date" in df.columns else "snapshot_date"
+        return df[df[_date_col] == picked], picked
+    # Fast path: searchsorted 로 후보 찾기
+    side = "left" if strict_less else "right"
+    idx = unique_dates.searchsorted(target_date, side=side) - 1
+    if idx < 0:
+        if fallback_first and len(unique_dates) > 0:
+            picked = unique_dates[0]
+        else:
+            return None, None
+    else:
+        picked = unique_dates[idx]
+    i_start, i_end = date_ranges[picked]
+    return df.iloc[i_start:i_end], picked
+
+
 def _get_fwd_for_date(calc_date: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     """프리페치 캐시에서 포워드 데이터 추출."""
-    fwd_all = _prefetch_cache["forward"]
-    dates = fwd_all["trade_date"].unique()
-    dates_before = sorted(d for d in dates if d < calc_date)
-    fwd_date = dates_before[-1] if dates_before else (sorted(dates)[0] if len(dates) else None)
-    fwd_df = fwd_all[fwd_all["trade_date"] == fwd_date].drop(columns=["trade_date"]) if fwd_date else pd.DataFrame()
+    fwd_slice, fwd_date = _fast_slice_by_date("forward", "forward", calc_date,
+                                              strict_less=True, fallback_first=True)
+    fwd_df = fwd_slice.drop(columns=["trade_date"]) if fwd_slice is not None else pd.DataFrame()
 
     three_m_ago = (datetime.strptime(calc_date, "%Y-%m-%d") - timedelta(days=90)).strftime("%Y-%m-%d")
-    dates_3m = sorted(d for d in dates if d <= three_m_ago)
-    fwd_date_3m = dates_3m[-1] if dates_3m else None
+    fwd_3m_slice, _ = _fast_slice_by_date("forward", "forward", three_m_ago, strict_less=False)
     fwd_3m_df = pd.DataFrame()
-    if fwd_date_3m:
-        fwd_3m_df = fwd_all[fwd_all["trade_date"] == fwd_date_3m][["stock_code", "fwd_eps"]].copy()
+    if fwd_3m_slice is not None:
+        fwd_3m_df = fwd_3m_slice[["stock_code", "fwd_eps"]].copy()
         fwd_3m_df = fwd_3m_df.rename(columns={"fwd_eps": "fwd_eps_3m"})
     return fwd_df, fwd_3m_df
 
 
 def _get_price_for_date(calc_date: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     """프리페치 캐시에서 주가 데이터 추출."""
-    price_all = _prefetch_cache["price"]
-    dates = price_all["trade_date"].unique()
-    dates_before = sorted(d for d in dates if d < calc_date)
-    price_date = dates_before[-1] if dates_before else None
-    price_df = price_all[price_all["trade_date"] == price_date][["stock_code", "close", "market_cap", "trade_amount"]] if price_date else pd.DataFrame()
+    price_slice, price_date = _fast_slice_by_date("price", "price", calc_date, strict_less=True)
+    if price_slice is not None:
+        price_df = price_slice[["stock_code", "close", "market_cap", "trade_amount"]]
+    else:
+        price_df = pd.DataFrame()
 
     three_m_ago = (datetime.strptime(calc_date, "%Y-%m-%d") - timedelta(days=90)).strftime("%Y-%m-%d")
-    dates_3m = sorted(d for d in dates if d <= three_m_ago)
-    price_date_3m = dates_3m[-1] if dates_3m else None
+    price_3m_slice, _ = _fast_slice_by_date("price", "price", three_m_ago, strict_less=False)
     price_3m_df = pd.DataFrame()
-    if price_date_3m:
-        price_3m_df = price_all[price_all["trade_date"] == price_date_3m][["stock_code", "close"]].copy()
+    if price_3m_slice is not None:
+        price_3m_df = price_3m_slice[["stock_code", "close"]].copy()
         price_3m_df = price_3m_df.rename(columns={"close": "close_3m"})
     return price_df, price_3m_df
 
@@ -834,12 +927,12 @@ def _calc_obv_slope(price_all: pd.DataFrame, calc_date: str, obv_ma: int = 20, m
 
 def _get_master_for_date(calc_date: str) -> pd.DataFrame:
     """프리페치 캐시에서 마스터 데이터 추출."""
-    master_all = _prefetch_cache["master"]
     snap_month = calc_date[:7]
-    snaps = sorted(master_all["snapshot_date"].unique())
-    valid_snaps = [s for s in snaps if s <= snap_month]
-    snap = valid_snaps[-1] if valid_snaps else (snaps[0] if snaps else snap_month)
-    return master_all[master_all["snapshot_date"] == snap][["stock_code", "stock_name", "market", "sec_cd_nm", "finacc_typ"]]
+    master_slice, _ = _fast_slice_by_date("master", "master", snap_month,
+                                          strict_less=False, fallback_first=True)
+    if master_slice is None:
+        return pd.DataFrame(columns=["stock_code", "stock_name", "market", "sec_cd_nm", "finacc_typ"])
+    return master_slice[["stock_code", "stock_name", "market", "sec_cd_nm", "finacc_typ"]]
 
 
 def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = None) -> pd.DataFrame | None:


### PR DESCRIPTION
## 요약

\`_get_price/forward/master_for_date\` 매 호출에서 \`df["trade_date"].unique() + sorted + boolean indexing on 6M rows\` 반복하던 패턴을 제거하고, prefetch 시 date 별 슬라이스 인덱스를 미리 계산.

## 측정 (로컬, calc_date=2025-06-01, repeat=10)

| 함수 | 옛 | 새 | 배수 |
|------|----|----|------|
| _get_price_for_date | 1300ms | **0.7ms** | 1756x |
| _get_fwd_for_date | 106ms | **0.3ms** | 347x |
| _get_master_for_date | 23ms | **0.1ms** | 189x |
| **합계 (호출당)** | **1430ms** | **1.2ms** | **1223x** |

**결과 동일성: ✅ 5개 DataFrame 비교 모두 OK** (df_equal 통과)

**예상 백테스트 영향:** ~300s → ~160s (1분 40초 절감)

## 구현

1. \`_build_date_indices()\` 추가:
   - price/forward/master 를 date 기준 sort + reset_index
   - date 별 (start, end) 인덱스 dict
   - unique dates numpy 배열
2. \`_fast_slice_by_date()\` 헬퍼:
   - searchsorted 로 후보 date 찾기
   - iloc[start:end] 로 슬라이싱 (boolean indexing 대체)
3. \`_get_price/forward/master_for_date\` 가 헬퍼 호출

## 호환성

- 인덱스 미생성 시 옛 로직 fallback 자동 작동
- disk cache 로드 경로 / 기존 메모리 캐시 경로 둘 다 \`_build_date_indices()\` 호출
- \`_factor_data_cache\` 등 기존 다른 캐시 영향 없음

## 회귀 위험

- 메모리 +수백MB (\`sort_values + reset_index\` 임시) — production 모니터링 필요
- 단, PR #24 와 다르게 호출당 시간이 명확히 떨어짐 (1223x) + 결과 동일성 OK

## Test plan
- [ ] Railway 배포 후 [TIMING-LOAD] slice 가 ~0.1s 로 떨어지는지 확인
- [ ] [PREFETCH] date indices built in Xs 로그 확인
- [ ] 백테스트 결과 (누적수익률) 가 기존과 동일한지 비교
- [ ] Railway Metrics 에서 메모리 사용량 확인

PoC: \`analysis/profile_slice.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)