### PR TITLE
perf: _indicators_db_cache 도 prefetch stale 시 자동 무효화 (Option A)

### DIFF
--- a/lib/factor_engine.py
+++ b/lib/factor_engine.py
@@ -217,6 +217,7 @@ def prefetch_all_data(conn, use_local_cache=True):
                 print(f"[PREFETCH] 메모리 캐시 stale 감지: mem={mem_max}, db={db_max_trade_date} → 무효화 + 재로드", flush=True)
                 _prefetch_cache.clear()
                 clear_indicator_cache()  # MA/MFI/OBV 캐시도 무효화
+                clear_indicators_db_cache()  # alpha_lab.stock_indicators DB 캐시 (PR #22+#27) 도 무효화
 
         if use_local_cache and db_max_trade_date and meta_path.exists():
             try:
@@ -332,6 +333,7 @@ def prefetch_all_data(conn, use_local_cache=True):
         _prefetch_cache["_max_trade_date"] = db_max_trade_date
     # MA/MFI/OBV 인디케이터 캐시도 무효화 (price 데이터가 새로 로드됐으므로)
     clear_indicator_cache()
+    clear_indicators_db_cache()  # alpha_lab.stock_indicators DB 캐시 (PR #22+#27) 도 무효화
 
     # ── slice 최적화: trade_date / snapshot_date 별 슬라이스 인덱스 미리 계산 ──
     # 매 _get_*_for_date 호출에서 unique() + sort + boolean indexing on 6M rows 반복 제거.


### PR DESCRIPTION
## 문제

PR #22+#27 에서 추가된 \`_indicators_db_cache\` (alpha_lab.stock_indicators 메모리 캐시) 가 prefetch stale 시스템에 연동 안 됨.

### 영향
- run_pipeline 으로 새 데이터 들어와도 backend 재배포 전까지 옛 indicators 캐시 사용
- prefetch_cache (price/finance/etc) 와 _ma/_mfi/_obv_indicator_cache 는 PR #16/PR #20 으로 자동 stale 무효화 됐지만, _indicators_db_cache 만 누락

## 해결

\`prefetch_all_data\` 의 stale 감지 spot 2곳에 \`clear_indicators_db_cache()\` 추가. 기존 \`clear_indicator_cache()\` 와 동일 패턴.

```diff
                 _prefetch_cache.clear()
                 clear_indicator_cache()  # MA/MFI/OBV 캐시도 무효화
+                clear_indicators_db_cache()  # alpha_lab.stock_indicators DB 캐시도 무효화
```

## 작동 흐름 (PR 후)

```
[LG gram 또는 다른 환경] run_pipeline → Railway PG 에 daily_price 새 행 INSERT
                                       ↓
[Railway backend] 사용자 백테스트 클릭
  → run_strategy_backtest → prefetch_all_data 호출 (매번)
  → SELECT MAX(trade_date) FROM daily_price → 메모리 캐시와 비교
  → 다르면 (= 새 데이터) stale 감지
  → 모든 캐시 무효화 + reload:
       prefetch_cache (price/finance/forward/master) ✓
       _ma/_mfi/_obv_indicator_cache ✓
       _indicators_db_cache ✓ ← 본 PR 이 추가
  → 새 데이터로 백테스트
```

**backend 재배포 없이 자동 갱신 완성.**

## 회귀 위험

- 매우 작음. clear 함수 호출 2줄 추가만.
- stale 일 때만 호출 (= 데이터 갱신 직후 첫 백테스트). 평상시 영향 없음.
- stale 감지 후 첫 백테스트만 indicators_db_cache reload (Railway internal ~10초)

## Test plan
- [ ] Railway 배포 후 첫 백테스트는 평소처럼 작동
- [ ] LG gram 에서 run_pipeline 으로 새 데이터 적재 후 웹뷰에서 백테스트
- [ ] Railway logs 에서 \`[PREFETCH] 메모리 캐시 stale 감지\` + \`[INDICATORS_DB] Loading\` 보이는지
- [ ] 새 데이터의 영향 받는 결과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)