### PR TITLE
fix: ATT 회귀 결측 NaN 유지 + dead CURRENT 팩터 제거

### DIFF
--- a/lib/ai.py
+++ b/lib/ai.py
@@ -77,7 +77,7 @@ DB에서 로딩되는 재무/주가/Forward 데이터:
 - 밸류: t_per (trailing PER), f_per (forward PER), t_ev_ebitda, f_ev_ebitda, f_ev_ebit, ev_ic, f_pbr, t_pcf
 - 성장: f_epsg (forward EPS 성장률), f_ebitg (forward EBIT 성장률), t_spsg (trailing 매출성장률), f_spsg (forward 매출성장률)
 - 모멘텀: f_eps_m (forward EPS 3개월 변화율), price_m (3개월 주가 모멘텀)
-- 재무건전성: ndebt_ebitda (순차입/EBITDA), current_ratio (유동비율)
+- 재무건전성: ndebt_ebitda (순차입/EBITDA)
 
 ## 회귀 모델 formula_type
 - "ratio": fitted / actual - 1 (예: PBR-ROE, Forward PER-이익성장)
@@ -147,14 +147,13 @@ FACTOR_LABELS = {
     "F_EPS_M": "Forward EPS 모멘텀",
     "PRICE_M": "3개월 주가모멘텀",
     "NDEBT_EBITDA": "순차입/EBITDA",
-    "CURRENT": "유동비율",
 }
 
 FACTOR_CATEGORIES = {
     "밸류에이션": ["T_PER", "F_PER", "T_EVEBITDA", "F_EVEBITDA", "T_PBR", "F_PBR", "T_PCF"],
     "회귀 매력도": ["ATT_PBR", "ATT_EVIC", "ATT_PER", "ATT_EVEBIT"],
     "성장성": ["T_SPSG", "F_SPSG"],
-    "차별화": ["F_EPS_M", "PRICE_M", "NDEBT_EBITDA", "CURRENT"],
+    "차별화": ["F_EPS_M", "PRICE_M", "NDEBT_EBITDA"],
 }
 
 # 채팅 예시 (UI에서 사용)

--- a/lib/factor_engine.py
+++ b/lib/factor_engine.py
@@ -57,7 +57,7 @@ def decile_rule1(series):
 
 
 def decile_rule2(series):
-    """높을수록 좋음 (회귀/성장/CURRENT). P90이상->10 ... P10이하->1, NaN->0"""
+    """높을수록 좋음 (회귀/성장). P90이상->10 ... P10이하->1, NaN->0"""
     P = _pcts(series)
     if P is None:
         return pd.Series(0, index=series.index)
@@ -1449,8 +1449,6 @@ def load_factor_data(conn, calc_date: str, ma_reversion_window: int | None = Non
     m = merged[ebitda_col].notna() & (merged[ebitda_col] > 0) & merged["net_debt"].notna()
     merged["ndebt_ebitda"] = np.where(m, merged["net_debt"] / merged[ebitda_col], np.nan)
 
-    merged["current_ratio"] = np.nan
-
     # FCF_YIELD
     if "fcf" in merged.columns:
         m = merged["fcf"].notna() & (merged["market_cap"] > 0)
@@ -1525,7 +1523,8 @@ def _run_single_regression(df, x_col, y_col, model_name, formula_type, outlier_f
     y_max = outlier_filter.get("y_max", 9999)
 
     if x_col not in df.columns or y_col not in df.columns:
-        df[col_attr] = 0.0
+        # 결측은 NaN 유지 → 사분위 점수 0, 분포 오염 없음
+        df[col_attr] = np.nan
         return df, {"model": model_name, "n": 0, "r2": 0, "status": "missing_column"}
 
     vm = (df[x_col].notna() & df[y_col].notna() &
@@ -1534,12 +1533,12 @@ def _run_single_regression(df, x_col, y_col, model_name, formula_type, outlier_f
     valid = df[vm].copy()
 
     if len(valid) < 20:
-        df[col_attr] = 0.0
+        df[col_attr] = np.nan
         return df, {"model": model_name, "n": len(valid), "r2": 0, "status": "insufficient"}
 
     # x값이 전부 같으면 회귀 불가
     if valid[x_col].nunique() < 2:
-        df[col_attr] = 0.0
+        df[col_attr] = np.nan
         return df, {"model": model_name, "n": len(valid), "r2": 0, "status": "constant_x"}
 
     slope, intercept, r_value, _, _ = stats.linregress(valid[x_col].values, valid[y_col].values)
@@ -1577,7 +1576,8 @@ def _run_single_regression(df, x_col, y_col, model_name, formula_type, outlier_f
         mask = has_x & df[y_col].notna() & (df[y_col].abs() > 0)
         df.loc[mask, col_attr] = (fitted[mask] - df.loc[mask, y_col]) / df.loc[mask, y_col].abs()
 
-    df[col_attr] = df[col_attr].clip(-1.0, 5.0).fillna(0.0)
+    # NaN 은 유지 → 결측 종목이 분포에 끼지 않게 (사분위 점수 0)
+    df[col_attr] = df[col_attr].clip(-1.0, 5.0)
     return df, {
         "model": model_name, "n": len(valid), "r2": round(r2, 4),
         "slope": round(slope, 4), "intercept": round(intercept, 4), "status": "ok",
@@ -2144,7 +2144,6 @@ SCORE_MAP = {
     "T_SPSG": "t_spsg_score", "F_SPSG": "f_spsg_score",
     "F_EPS_M": "f_eps_m_score",
     "PRICE_M": "price_m_score", "NDEBT_EBITDA": "ndebt_ebitda_score",
-    "CURRENT": "current_ratio_score",
     "PRICE_MA_REV": "price_ma_rev_score",
     "OBV_SLOPE": "obv_slope_score",
     "MFI": "mfi_score",
@@ -2153,7 +2152,7 @@ SCORE_MAP = {
 
 # ─── 스코어링 규칙 ───
 # "rule1": 낮을수록 좋음 (밸류 멀티플: PER, PBR, EV/EBITDA, PCF)
-# "rule2": 높을수록 좋음 (회귀 매력도, 성장률, EPS 모멘텀, 유동비율)
+# "rule2": 높을수록 좋음 (회귀 매력도, 성장률, EPS 모멘텀)
 # "rule3": 낮을수록 좋음 (주가 모멘텀 역방향, 부채비율)
 SCORING_RULES = {
     "t_per": "rule1", "f_per": "rule1",
@@ -2166,7 +2165,6 @@ SCORING_RULES = {
     "t_spsg": "rule2", "f_spsg": "rule2",
     "f_eps_m": "rule2",
     "price_m": "rule3", "ndebt_ebitda": "rule3",
-    "current_ratio": "rule2",
     "price_ma_rev": "rule2",
     "obv_slope": "rule2",
     "mfi": "rule2",


### PR DESCRIPTION
## 배경

\`analysis/inspect_factor_scores.py\` 로 \`수정전략_코스피_cap30%_top30_tx30bp_월간\` 의 2026-05-04 리밸 상위 30종목 팩터 점수 검수 중 두 가지 문제 발견.

## 문제 1: ATT 회귀 결측 → fillna(0.0) 분포 오염 (weight 30%)

\`_run_single_regression\` 가 회귀 실패/결측 시 \`df[col_attr] = 0.0\` 강제.
clip 후 \`.fillna(0.0)\` 도 NaN → 0 변환.

**결과**: 데이터 누락 종목이 raw=0 으로 분포 중앙에 박혀 사분위에서 "중립값" 점수 받음.
**예시**: 영원무역(A111770) — TTM_4Q 의 BS 항목 (\`net_debt\`/\`ic\`/\`total_equity\`/\`bps\`/\`pcf\`) 통째로 누락된 종목인데:
- T_EVEBITDA / F_EVEBITDA / T_PBR / T_PCF → null (정상)
- **ATT_PBR / ATT_EVIC / ATT_PER / ATT_EVEBIT → raw=0.00, score=3~4**
- final 70점 중 ATT 4개 × ~3.5점 × weight = 10점+ 가 노이즈로 충당

ATT weight 가 30% (가장 큰 그룹) 라 영향 큼.

### 수정 (factor_engine.py:1525-1577)

```diff
- if x_col not in df.columns or y_col not in df.columns:
-     df[col_attr] = 0.0
+ if x_col not in df.columns or y_col not in df.columns:
+     df[col_attr] = np.nan  # 결측은 NaN 유지 → 사분위 점수 0

- if len(valid) < 20:
-     df[col_attr] = 0.0
+     df[col_attr] = np.nan

- if valid[x_col].nunique() < 2:
-     df[col_attr] = 0.0
+     df[col_attr] = np.nan

- df[col_attr] = df[col_attr].clip(-1.0, 5.0).fillna(0.0)
+ df[col_attr] = df[col_attr].clip(-1.0, 5.0)
```

→ NaN 유지 시 \`quartile_rule2\` 에서 NaN → score=0, 분포 사분위 계산에서도 제외 → 다른 종목들의 사분위 경계가 정확해짐.

## 문제 2: CURRENT(유동비율) dead code

- \`merged[\"current_ratio\"] = np.nan\` 으로 계산 미구현
- UI 입력란 없음 + DB 활성 전략 중 weight > 0 케이스 없음
- 다만 SCORE_MAP / SCORING_RULES / FACTOR_CATEGORIES 에 등록돼 있어서 AI 자동 추천 시 침묵 실패 가능 (추천해도 weight 적용 불가)

### 제거 (5곳)

- \`lib/factor_engine.py\`: \`current_ratio = np.nan\` 라인, SCORE_MAP, SCORING_RULES, decile_rule2 docstring
- \`lib/ai.py\`: FACTOR_LABELS, FACTOR_CATEGORIES \"차별화\", 주석 (line 80)

## 영향

- 다음 백테스트부터 ATT 점수 분포가 정확해짐 (결측 종목 제외 후 사분위)
- 누적수익률에 약간 영향 가능 (ATT 비중 큰 전략에서)
- AI 추천에서 dead factor CURRENT 사라짐

## Test plan
- [ ] inspect_factor_scores.py 로 영원무역 같은 BS 누락 종목 ATT 점수가 raw=NaN, score=0 으로 표시되는지 확인
- [ ] 백테스트 재실행 후 누적수익률 변화 검증
- [ ] AI 추천 시 CURRENT 안 나오는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)