### PR TITLE
fix: TTM 계산 시 4Q BS NaN → Annual fallback (1574종목 BS 복원)

### DIFF
--- a/scripts/step5b_calc_ttm.py
+++ b/scripts/step5b_calc_ttm.py
@@ -110,6 +110,21 @@ def calc_ttm():
     df["qtr_idx"] = df.apply(lambda r: qtr_index(r["fiscal_year"], r["qtr_num"]), axis=1)
     df = df.sort_values(["stock_code", "qtr_idx"]).reset_index(drop=True)
 
+    # Annual BS fallback 맵 — fnspace 가 4Q 분기보고서에 BS 안 보내는 케이스 보정
+    # (2025 4Q 의 70% 종목이 BS NaN, Annual 에는 정상)
+    print("  Annual BS fallback 데이터 로드 중...")
+    ann_rows = conn.execute("""
+        SELECT stock_code, fiscal_year, bps, net_debt, interest_debt, total_equity, ic, div_yield, pcf
+        FROM fnspace_finance
+        WHERE fiscal_quarter = 'Annual'
+    """).fetchall()
+    annual_fallback_cols = STOCK_COLS + EXTRA_COLS  # bps, net_debt, interest_debt, total_equity, ic, div_yield, pcf
+    annual_bs_map = {}
+    for r in ann_rows:
+        sc, fy = r[0], int(r[1])
+        annual_bs_map[(sc, fy)] = dict(zip(annual_fallback_cols, r[2:]))
+    print(f"  Annual BS map: {len(annual_bs_map):,}건")
+
     # 시가총액 로드
     mcap_map = load_mcap_map(conn)
 
@@ -135,9 +150,20 @@ def calc_ttm():
             for c in FLOW_COLS:
                 s = window[c].dropna()
                 values[c] = float(s.sum()) if len(s) > 0 else None
+            # BS/extra 항목: 마지막 분기 값 → NaN 이면 같은 연도 Annual 에서 fallback
+            ann = annual_bs_map.get((code, end_year))
             for c in STOCK_COLS + EXTRA_COLS:
                 v = last[c]
-                values[c] = None if (v is None or (isinstance(v, float) and np.isnan(v))) else float(v)
+                if v is None or (isinstance(v, float) and np.isnan(v)):
+                    # Fallback: Annual row 의 같은 컬럼
+                    if ann is not None:
+                        av = ann.get(c)
+                        if av is not None and not (isinstance(av, float) and np.isnan(av)):
+                            values[c] = float(av)
+                            continue
+                    values[c] = None
+                else:
+                    values[c] = float(v)
 
             te = values.get("total_equity")
             ni = values.get("net_income")


### PR DESCRIPTION
## 문제

fnspace 가 **4Q 분기보고서에 BS(재무상태표) 안 보내고 Annual(사업보고서) 에만 포함**. 한국 회계 보고 관행 — 4Q 보고 시점이 사업보고서와 겹쳐서.

### 영향 (2025년 기준)
- 2025 4Q 의 **70% 종목 (1,574/2,250)** 이 BS NaN
- \`step5b_calc_ttm.py\` 가 TTM_4Q 계산 시 BS 를 마지막 분기 (=4Q) 에서 그대로 가져옴
- → 1,574종목의 \`TTM_4Q\` BS = None
- → factor_engine 의 ATT 회귀 (weight 30%) 가 1,574종목 raw=0 으로 처리 → 분포 사분위 오염

### 영원무역 (A111770) 케이스
| 분기 | BS 상태 |
|------|--------|
| 2025 1Q/2Q/3Q | ✅ BS 정상 |
| 2025 4Q | ❌ BS 모두 None |
| **2025 Annual** | ✅ **BS 정상 ← 여기 있음** |
| 2025 TTM_4Q | ❌ 계산 시 4Q 사용 → BS None |

## 수정 (\`scripts/step5b_calc_ttm.py\`)

1. Annual BS fallback 맵 사전 로드: \`(stock_code, fiscal_year) → BS 값\`
2. TTM 계산 시 마지막 분기의 BS 가 NaN 이면 같은 연도 Annual 값으로 fallback
3. STOCK_COLS (bps, net_debt, interest_debt, total_equity, ic) + EXTRA_COLS (div_yield, pcf) 모두 적용

## 적용 방법

```bash
python scripts/step5b_calc_ttm.py  # TTM 재계산 (~수 분)
# 또는 run_pipeline.py 의 TTM step 재실행
```

## 기대 효과
- 1,574종목의 TTM_4Q BS 정상 복원
- ATT 점수 분포 정확
- 2026년 백테스트의 ATT weight 큰 전략에서 누적수익률 변화 (긍정적 방향 예상)

## Test plan
- [ ] step5b 재실행 후 \`SELECT COUNT(*) FROM fnspace_finance WHERE fiscal_quarter='TTM_4Q' AND fiscal_year=2025 AND net_debt IS NULL\` 결과 < 100
- [ ] 영원무역 (A111770) TTM_4Q 의 net_debt, bps, ic, total_equity 가 Annual 값으로 채워지는지 확인
- [ ] inspect_factor_scores.py 로 백테스트 재실행 후 ATT 점수 분포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)