### PR TITLE
fix: TTM FLOW 4Q 누락 Annual fallback (silent under-estimate 해소)

### DIFF
--- a/analysis/audit_factor_coverage.py
+++ b/analysis/audit_factor_coverage.py
@@ -1,0 +1,221 @@
+"""
+analysis/audit_factor_coverage.py
+
+팩터 계산에 쓰이는 모든 컬럼의 coverage (NaN%) 를 fiscal/시간 축 별로 audit.
+
+목적:
+  fnspace 4Q BS 누락 같은 데이터 quirk 를 한눈에 노출.
+  특정 시점 / 컬럼의 NaN 비율이 다른 시점 대비 비정상적으로 높으면 회귀 의심.
+
+검사 범위:
+  1. fnspace_finance     — 22+ 컬럼 (TTM/Annual 별, fiscal_year × fiscal_quarter)
+  2. fnspace_forward     — 10+ 컬럼 (year-month 별)
+  3. stock_indicators    — ma_120, mfi_val 등 (year-month 별)
+  4. daily_price         — close, market_cap (year-month 별)
+
+실행:
+  python analysis/audit_factor_coverage.py                       # 전체 출력
+  python analysis/audit_factor_coverage.py --since 2024          # 2024년 이후만
+  python analysis/audit_factor_coverage.py --csv out_dir/        # CSV 저장
+  python analysis/audit_factor_coverage.py --section finance     # 특정 섹션만
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+import pandas as pd
+from lib.db import get_conn
+
+
+# 팩터 사용 컬럼 정의 (factor_engine.py 의 SELECT 와 동기화)
+FINANCE_COLS = [
+    # FLOW
+    "ebit", "ebitda", "eps", "revenue", "operating_income", "net_income",
+    # STOCK (BS)
+    "bps", "net_debt", "interest_debt", "total_equity", "ic",
+    # EXTRA
+    "div_yield", "pcf",
+    # Derived
+    "pbr", "per", "psr", "ev_ebitda", "ev_ebit", "ev", "roe", "roic", "oi_margin",
+]
+
+FORWARD_COLS = [
+    "fwd_eps", "fwd_per", "fwd_ebit", "fwd_ebitda", "fwd_ev_ebitda",
+    "fwd_revenue", "fwd_oi", "fwd_ni", "fwd_roe", "fwd_bps",
+]
+
+INDICATOR_COLS = ["ma_120", "deviation_120", "mfi_val", "pos_sum_14", "neg_sum_14"]
+
+PRICE_COLS = ["close", "market_cap"]
+
+
+def nan_pct_pivot(df: pd.DataFrame, group_cols: list[str], value_cols: list[str]) -> pd.DataFrame:
+    """group_cols 별로 각 value_col 의 NaN% 와 total count 를 계산."""
+    out = []
+    for keys, g in df.groupby(group_cols, dropna=False):
+        row = {gc: (keys if not isinstance(keys, tuple) else keys[i])
+               for i, gc in enumerate(group_cols if isinstance(keys, tuple) else [group_cols[0]])}
+        # tuple unpack 안전 처리
+        if isinstance(keys, tuple):
+            for i, gc in enumerate(group_cols):
+                row[gc] = keys[i]
+        else:
+            row[group_cols[0]] = keys
+        row["n"] = len(g)
+        for col in value_cols:
+            if col not in g.columns:
+                row[col] = "—"
+            else:
+                nan_n = g[col].isna().sum()
+                row[col] = f"{nan_n / len(g) * 100:.0f}%" if len(g) > 0 else "—"
+        out.append(row)
+    result = pd.DataFrame(out).sort_values(group_cols).reset_index(drop=True)
+    return result
+
+
+def audit_finance(conn, since_year: int | None = None) -> pd.DataFrame:
+    print("\n" + "=" * 80)
+    print("  [1/4] fnspace_finance — TTM/Annual coverage by (fiscal_year, fiscal_quarter)")
+    print("=" * 80)
+
+    cols_select = ", ".join(FINANCE_COLS)
+    where = f"WHERE fiscal_year >= {since_year}" if since_year else ""
+    sql = f"""
+        SELECT stock_code, fiscal_year, fiscal_quarter, {cols_select}
+        FROM fnspace_finance
+        {where}
+        ORDER BY fiscal_year DESC, fiscal_quarter
+    """
+    df = pd.read_sql(sql, conn._conn)
+    if len(df) == 0:
+        print("  (데이터 없음)")
+        return pd.DataFrame()
+
+    pivot = nan_pct_pivot(df, ["fiscal_year", "fiscal_quarter"], FINANCE_COLS)
+    print(pivot.to_string(index=False))
+    return pivot
+
+
+def audit_forward(conn, since_year: int | None = None) -> pd.DataFrame:
+    print("\n" + "=" * 80)
+    print("  [2/4] fnspace_forward — consensus coverage by year-month")
+    print("=" * 80)
+
+    cols_select = ", ".join(FORWARD_COLS)
+    where = f"WHERE trade_date >= '{since_year}-01-01'" if since_year else ""
+    sql = f"""
+        SELECT stock_code, trade_date, {cols_select}
+        FROM fnspace_forward
+        {where}
+        ORDER BY trade_date DESC
+    """
+    df = pd.read_sql(sql, conn._conn)
+    if len(df) == 0:
+        print("  (데이터 없음)")
+        return pd.DataFrame()
+
+    df["ym"] = pd.to_datetime(df["trade_date"]).dt.strftime("%Y-%m")
+    pivot = nan_pct_pivot(df, ["ym"], FORWARD_COLS)
+    print(pivot.to_string(index=False))
+    return pivot
+
+
+def audit_indicators(conn, since_year: int | None = None) -> pd.DataFrame:
+    print("\n" + "=" * 80)
+    print("  [3/4] stock_indicators — MA/MFI coverage by year-month")
+    print("=" * 80)
+
+    cols_select = ", ".join(INDICATOR_COLS)
+    where = f"WHERE trade_date >= '{since_year}-01-01'" if since_year else ""
+    sql = f"""
+        SELECT stock_code, trade_date, {cols_select}
+        FROM alpha_lab.stock_indicators
+        {where}
+    """
+    try:
+        df = pd.read_sql(sql, conn._conn)
+    except Exception as e:
+        print(f"  (조회 실패: {e})")
+        return pd.DataFrame()
+    if len(df) == 0:
+        print("  (데이터 없음)")
+        return pd.DataFrame()
+
+    df["ym"] = pd.to_datetime(df["trade_date"]).dt.strftime("%Y-%m")
+    pivot = nan_pct_pivot(df, ["ym"], INDICATOR_COLS)
+    print(pivot.to_string(index=False))
+    return pivot
+
+
+def audit_price(conn, since_year: int | None = None) -> pd.DataFrame:
+    print("\n" + "=" * 80)
+    print("  [4/4] daily_price — close/market_cap coverage by year-month")
+    print("=" * 80)
+
+    cols_select = ", ".join(PRICE_COLS)
+    where = f"WHERE trade_date >= '{since_year}-01-01'" if since_year else ""
+    sql = f"""
+        SELECT stock_code, trade_date, {cols_select}
+        FROM daily_price
+        {where}
+    """
+    df = pd.read_sql(sql, conn._conn)
+    if len(df) == 0:
+        print("  (데이터 없음)")
+        return pd.DataFrame()
+
+    df["ym"] = pd.to_datetime(df["trade_date"]).dt.strftime("%Y-%m")
+    pivot = nan_pct_pivot(df, ["ym"], PRICE_COLS)
+    print(pivot.to_string(index=False))
+    return pivot
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--since", type=int, default=2023,
+                        help="시작 연도 (기본 2023). 전체는 0 또는 음수.")
+    parser.add_argument("--csv", type=str, default=None,
+                        help="CSV 저장 디렉토리 (예: out/coverage/)")
+    parser.add_argument("--section", type=str, default="all",
+                        choices=["all", "finance", "forward", "indicators", "price"])
+    args = parser.parse_args()
+
+    since = args.since if args.since and args.since > 0 else None
+    conn = get_conn()
+
+    results = {}
+    if args.section in ("all", "finance"):
+        results["finance"] = audit_finance(conn, since)
+    if args.section in ("all", "forward"):
+        results["forward"] = audit_forward(conn, since)
+    if args.section in ("all", "indicators"):
+        results["indicators"] = audit_indicators(conn, since)
+    if args.section in ("all", "price"):
+        results["price"] = audit_price(conn, since)
+
+    if args.csv:
+        out_dir = Path(args.csv)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for name, df in results.items():
+            if df is None or len(df) == 0:
+                continue
+            path = out_dir / f"coverage_{name}.csv"
+            df.to_csv(path, index=False)
+            print(f"  → {path}")
+
+    print("\n" + "=" * 80)
+    print("  팁:")
+    print("  - 같은 컬럼이 특정 (year, quarter) 에서만 NaN% 급등 → fnspace 데이터 quirk")
+    print("  - 모든 quarter 에서 일관되게 높은 NaN% → 그 컬럼은 쓰지 말아야 할 dead 컬럼")
+    print("  - TTM_4Q 의 BS (bps/net_debt/interest_debt/total_equity/ic) 가 ~70% 면")
+    print("    Annual fallback (PR #31) 이 아직 데이터에 반영 안 됨 — step5b 재실행 필요")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/step5b_calc_ttm.py
+++ b/scripts/step5b_calc_ttm.py
@@ -110,20 +110,53 @@ def calc_ttm():
     df["qtr_idx"] = df.apply(lambda r: qtr_index(r["fiscal_year"], r["qtr_num"]), axis=1)
     df = df.sort_values(["stock_code", "qtr_idx"]).reset_index(drop=True)
 
-    # Annual BS fallback 맵 — fnspace 가 4Q 분기보고서에 BS 안 보내는 케이스 보정
-    # (2025 4Q 의 70% 종목이 BS NaN, Annual 에는 정상)
-    print("  Annual BS fallback 데이터 로드 중...")
-    ann_rows = conn.execute("""
-        SELECT stock_code, fiscal_year, bps, net_debt, interest_debt, total_equity, ic, div_yield, pcf
+    # Annual fallback 맵 — fnspace 가 4Q 분기보고서에 derived/snapshot 항목을 안 채우는 케이스 보정
+    # (BS: 2025 4Q 의 70% NaN / EBIT·EBITDA: 70% NaN / EPS: 52% NaN — Annual 에는 정상)
+    # FLOW 는 Annual = 4분기 합산이므로 TTM_4Q (calendar year 와 align) 에만 적용
+    print("  Annual fallback 데이터 로드 중...")
+    annual_fallback_cols = FLOW_COLS + STOCK_COLS + EXTRA_COLS
+    _flow_sel = ", ".join(FLOW_COLS)
+    _stock_sel = ", ".join(STOCK_COLS + EXTRA_COLS)
+    ann_rows = conn.execute(f"""
+        SELECT stock_code, fiscal_year, {_flow_sel}, {_stock_sel}
         FROM fnspace_finance
         WHERE fiscal_quarter = 'Annual'
     """).fetchall()
-    annual_fallback_cols = STOCK_COLS + EXTRA_COLS  # bps, net_debt, interest_debt, total_equity, ic, div_yield, pcf
-    annual_bs_map = {}
+    annual_fallback_map = {}
     for r in ann_rows:
         sc, fy = r[0], int(r[1])
-        annual_bs_map[(sc, fy)] = dict(zip(annual_fallback_cols, r[2:]))
-    print(f"  Annual BS map: {len(annual_bs_map):,}건")
+        annual_fallback_map[(sc, fy)] = dict(zip(annual_fallback_cols, r[2:]))
+    print(f"  Annual fallback map: {len(annual_fallback_map):,}건")
+
+    # ─── FLOW pre-fill ──────────────────────────────────────────────────────
+    # fnspace 가 4Q 분기 row 에 derived FLOW (ebit/ebitda/eps) 안 채우는 케이스 보정.
+    # 한 분기만 NaN 이고 Annual + 나머지 3분기 모두 있으면
+    # `그 분기 값 = Annual − sum(known 3)` 으로 derive 해서 df 의 해당 row 에 직접 채움.
+    # 효과: TTM_4Q 뿐 아니라 TTM_1Q/2Q/3Q rolling window 가 (직전 연도의 4Q) 를 포함할 때도
+    # silent under-estimate (3분기 합을 4분기인 척) 방지.
+    print("  FLOW 분기 누락치 Annual fallback 보정 중...")
+    fill_counts = {c: 0 for c in FLOW_COLS}
+    for (sc, fy), group in df.groupby(["stock_code", "fiscal_year"], sort=False):
+        if len(group) != 4:
+            continue
+        ann = annual_fallback_map.get((sc, fy))
+        if not ann:
+            continue
+        for c in FLOW_COLS:
+            av = ann.get(c)
+            if av is None or (isinstance(av, float) and np.isnan(av)):
+                continue
+            col_vals = group[c]
+            nan_mask = col_vals.isna()
+            if nan_mask.sum() != 1:
+                continue
+            known_sum = col_vals.dropna().sum()
+            derived = float(av) - known_sum
+            idx_to_fill = group.index[nan_mask][0]
+            df.at[idx_to_fill, c] = derived
+            fill_counts[c] += 1
+    fill_summary = ", ".join(f"{c}:{n:,}" for c, n in fill_counts.items() if n > 0)
+    print(f"    derive 건수: {fill_summary or '0건'}")
 
     # 시가총액 로드
     mcap_map = load_mcap_map(conn)
@@ -147,11 +180,14 @@ def calc_ttm():
             ttm_qtr = QTR_LABEL[qtr_num]
 
             values = {}
+            ann = annual_fallback_map.get((code, end_year))
+            # FLOW 항목: 4분기 합산. 분기 누락은 위의 pre-fill 단계에서 보정됨.
+            # 그래도 4개가 안 모이면 (Annual NaN 이거나 다중 분기 누락) None 으로 emit
+            # — 3분기 합을 4분기인 척 (silent under-estimate) 방지.
             for c in FLOW_COLS:
                 s = window[c].dropna()
-                values[c] = float(s.sum()) if len(s) > 0 else None
+                values[c] = float(s.sum()) if len(s) == 4 else None
             # BS/extra 항목: 마지막 분기 값 → NaN 이면 같은 연도 Annual 에서 fallback
-            ann = annual_bs_map.get((code, end_year))
             for c in STOCK_COLS + EXTRA_COLS:
                 v = last[c]
                 if v is None or (isinstance(v, float) and np.isnan(v)):


### PR DESCRIPTION
## Summary
- PR #31 (BS Annual fallback) 후속 — fnspace 가 4Q 분기 row 에 derived FLOW (ebit/ebitda/eps) 도 안 채우는 quirk 추가 보정
- step5b 의 silent ~25% under-estimate (TTM_4Q + TTM_1Q/2Q/3Q 의 직전 4Q 포함 케이스) 해소
- 팩터 coverage audit 스크립트 신규 추가

## 변경
- `scripts/step5b_calc_ttm.py`
  - Annual fallback map 을 FLOW_COLS 까지 확장
  - Pre-fill 단계 추가: 한 분기만 NaN 이고 Annual + 나머지 3분기 모두 있으면 `Annual − sum(known 3)` 으로 derive 해서 df 의 해당 분기 row 에 채움
  - TTM rolling FLOW emit strict 화: `len(s) == 4` 일 때만 sum, 아니면 None
- `analysis/audit_factor_coverage.py` (신규)
  - 팩터에 쓰이는 4개 테이블 (fnspace_finance / fnspace_forward / stock_indicators / daily_price) NaN% audit

## 검증 결과

Pre-fill derive 건수 (step5b 단독 실행):
```
ebit:1,547, ebitda:1,547, eps:1,186, revenue:57, operating_income:37, net_income:38
```

| 항목 | Before | After |
|---|---|---|
| 2025 TTM_4Q BS (bps/net_debt/ic/total_equity/ev/roe) | 70% | 0~3% |
| 2025 TTM_4Q ev_ebitda / ev_ebit | 74% / 77% | 24% / 36% |
| 2025 TTM_\*Q div_yield (모든 분기) | 100% | 1~3% |
| 2025 TTM_4Q ebit/ebitda/eps | 1% (silent under) | 1% (정확한 4분기 합) |

## 가정 및 한계
- `Annual = Q1+Q2+Q3+Q4` 항등식 기반 — revenue/ebit/ebitda/op_income/net_income 은 정의상 정확
- EPS 만 연중 주식수 변동 (분할/유증/자사주) 있으면 근사 (fnspace 가 보통 retroactive 조정해서 차이 작음)
- TTM_1Q/2Q/3Q 의 window 가 직전 연도 4Q 를 포함하는 케이스도 자연 해결

## Test plan
- [x] step5b 단독 재실행 → Pre-fill 1,547+ 건 derive 확인
- [x] audit 재실행 → coverage 정상화 확인
- [ ] PR 머지 후 `python scripts/run_pipeline.py --monthly` 로 main 데이터 반영
- [ ] 백테스트 결과 (ATT weight 큰 전략의 2025 4Q 이후 수익률) 변동 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)