### PR TITLE
fix: 레짐 조합에서 stop_loss_basis 누락 → 전역 오염 의존 제거

### DIFF
--- a/lib/data.py
+++ b/lib/data.py
@@ -1747,6 +1747,8 @@ def run_regime_combo_backtest(
     bear_sl_pct = bear_params.get("stop_loss_pct", 15)
     bull_sl_mode = bull_params.get("stop_loss_mode", "sell")
     bear_sl_mode = bear_params.get("stop_loss_mode", "sell")
+    bull_sl_basis = bull_params.get("stop_loss_basis", "entry")
+    bear_sl_basis = bear_params.get("stop_loss_basis", "entry")
     _rebal = rebal_type or BACKTEST_CONFIG.get("rebal_type", "monthly")
     _universe = universe or BACKTEST_CONFIG.get("universe", "KOSPI")
 
@@ -2203,10 +2205,12 @@ def run_regime_combo_backtest(
             BACKTEST_CONFIG["stop_loss_enabled"] = bull_sl
             BACKTEST_CONFIG["stop_loss_pct"] = bull_sl_pct
             BACKTEST_CONFIG["stop_loss_mode"] = bull_sl_mode
+            BACKTEST_CONFIG["stop_loss_basis"] = bull_sl_basis
         else:
             BACKTEST_CONFIG["stop_loss_enabled"] = bear_sl
             BACKTEST_CONFIG["stop_loss_pct"] = bear_sl_pct
             BACKTEST_CONFIG["stop_loss_mode"] = bear_sl_mode
+            BACKTEST_CONFIG["stop_loss_basis"] = bear_sl_basis
         universe_set = get_universe_stocks(conn, calc_date)
         candidates = score_stocks_from_strategy(conn, calc_date, module)
         return [(c, s) for c, s in candidates if c in universe_set][:_top_n]
@@ -2220,6 +2224,7 @@ def run_regime_combo_backtest(
         "stop_loss_enabled": BACKTEST_CONFIG.get("stop_loss_enabled", False),
         "stop_loss_pct": BACKTEST_CONFIG.get("stop_loss_pct", 15),
         "stop_loss_mode": BACKTEST_CONFIG.get("stop_loss_mode", "sell"),
+        "stop_loss_basis": BACKTEST_CONFIG.get("stop_loss_basis", "entry"),
     }
     try:
         BACKTEST_CONFIG["top_n_stocks"] = top_n
@@ -2228,6 +2233,7 @@ def run_regime_combo_backtest(
         BACKTEST_CONFIG["stop_loss_enabled"] = bull_sl  # 초기값은 bull
         BACKTEST_CONFIG["stop_loss_pct"] = bull_sl_pct
         BACKTEST_CONFIG["stop_loss_mode"] = bull_sl_mode
+        BACKTEST_CONFIG["stop_loss_basis"] = bull_sl_basis
         BACKTEST_CONFIG["rebal_type"] = _rebal
         BACKTEST_CONFIG["universe"] = _universe
 


### PR DESCRIPTION
## Summary
- 레짐 조합 백테스트가 `stop_loss_basis` 를 PARAMS 에서 안 읽고 `BACKTEST_CONFIG` 전역 dict 의 잔존 값을 사용하는 버그 수정
- 결과적으로 호출 순서 / 세션 상태에 따라 entry/peak 가 비결정적으로 적용되던 문제 해결

## 증상

PG 의 strategy_code 에 `"stop_loss_basis": "peak"` 가 명시돼 있어도 레짐 조합 백테스트에서 entry default 가 적용되는 경우가 있었음.

사용자 발견 워크플로우:
- 단일 백테스트 (peak basis) → 저장 → 레짐 조합 → ✅ peak 작동
- 페이지 새로고침 / 서버 재시작 후 바로 레짐 조합 → ❌ entry default 적용

원인: `run_strategy_backtest` 가 `BACKTEST_CONFIG["stop_loss_basis"]` 를 set 한 후 `run_regime_combo_backtest` 가 호출되면, 레짐 조합이 그 잔존 값을 그대로 사용하는 전역 오염 (global pollution).

## 변경 (`lib/data.py`)

1. **`bull_sl_basis`, `bear_sl_basis` 변수 추가** ([line 1750-1751](lib/data.py#L1750))
   - 각 module 의 `PARAMS["stop_loss_basis"]` 에서 읽음, default `"entry"`

2. **`regime_stock_selector` 의 Bull/Bear 분기 양쪽에 basis set 추가** ([line 2205, 2210](lib/data.py#L2205))
   - 다른 stop_loss 항목 (`enabled`, `pct`, `mode`) 와 동일하게 처리

3. **`orig` 저장 dict + try 초기 설정에 basis 포함** ([line 2229, 2237](lib/data.py#L2229))
   - 함수 종료 시 원상복구 가능하도록

## 효과

```
이전:
  레짐 조합 결과 = f(strategy_code, BACKTEST_CONFIG 전역 상태)
  → 호출 순서 / 세션 의존, 비결정적

이후:
  레짐 조합 결과 = f(strategy_code 만)
  → 항상 PG 설정대로, 결정적
```

## Test plan
- [x] `from lib.data import run_regime_combo_backtest` 임포트 정상
- [ ] 백엔드 재시작 + 페이지 새로고침 후 레짐 조합 실행 → 콘솔 로그에 "고점대비=..." 형식 (peak basis 적용 확인)
- [ ] PG 의 strategy_code 에 `"stop_loss_basis": "peak"` 와 `"entry"` 양쪽 케이스에서 각각 일관되게 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)