### PR TITLE
fix: build_stock_indicators incremental 자기파괴 방지 (since=200→400)

### DIFF
--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -662,14 +662,18 @@ def step_build_stock_indicators(incremental: bool = False):
     """daily_price → MA/MFI indicator 미리 계산해서 alpha_lab.stock_indicators 적재.
     이러면 backend가 매 calc_date에 rolling 계산 안 함 (DB SELECT만).
 
-    incremental=True 면 최근 60일치만 재계산 (rolling window 안전 여유 포함).
+    incremental=True 면 최근 400일치 fetch 해서 rolling(120) 계산 후 UPSERT.
     """
     import subprocess
     args = [sys.executable, str(Path(__file__).parent / "build_stock_indicators.py")]
     if incremental:
-        # 최근 60영업일 재계산 (rolling 120 안전 여유)
+        # 400일 fetch — rolling(120) lookback 안전 확보.
+        # 이전 200일 fetch 는 fetch 의 첫 120일이 NaN 으로 UPSERT 되어
+        # 매번 실행마다 같은 6개월 구간이 NaN 으로 덮어씌워지는 자기파괴 버그.
+        # 400일이면 첫 120일 NaN 이라도 그 이전 데이터에 영향 없고
+        # 마지막 280일은 정상 MA 로 UPSERT 됨.
         from datetime import datetime as _dt, timedelta as _td
-        since = (_dt.now() - _td(days=200)).strftime("%Y-%m-%d")
+        since = (_dt.now() - _td(days=400)).strftime("%Y-%m-%d")
         args += ["--since", since]
     subprocess.run(args, check=True)
 


### PR DESCRIPTION
## Summary
- 매 monthly/daily 실행마다 stock_indicators 의 MA 5-6개월치가 NaN 으로 재망가지는 자기파괴 버그 fix
- `since=200` → `since=400` 한 줄 변경

## 문제

`step_build_stock_indicators(incremental=True)` 가 `since=200일전` 으로 호출하면:

1. `fetch_price` 가 200일치만 daily_price fetch
2. `compute_indicators` 가 `rolling(120, min_periods=120)` 계산
3. fetch 의 **첫 120일은 lookback 데이터가 fetch 범위 밖** → MA = NaN
4. UPSERT 가 그 NaN 값으로 stock_indicators 의 이전 정상 MA 를 덮어쓰기

결과: 매 실행마다 같은 5-6개월 구간이 NaN 으로 재발 (현재 2025-11~2026-04).

영향받는 factor: `PRICE_MA_REV`, `below_ma` — 그 기간 score = 0 silent penalty.

## 수정

[scripts/run_pipeline.py:670-672](scripts/run_pipeline.py#L670):
```python
# 이전: 200일 fetch (rolling 120 첫 120일 NaN 으로 덮어쓰기)
since = (_dt.now() - _td(days=200)).strftime("%Y-%m-%d")

# 변경: 400일 fetch — rolling 120 안전 여유 확보
since = (_dt.now() - _td(days=400)).strftime("%Y-%m-%d")
```

400일이면:
- 첫 120일 NaN (fetch 한 가장 옛날 자리, 실제 관심 영역 밖)
- 마지막 280일은 정상 MA 로 UPSERT
- 그 이전 데이터는 fetch 안 되어 UPSERT 영향 없음 (기존 값 유지)

## 검증

```bash
# 현재 갭 메우기 (이번 PR 머지 직후 한 번)
python scripts/build_stock_indicators.py

# 다음 monthly 실행 후 audit
python analysis/audit_factor_coverage.py --section indicators --since 2025
```

기대: 갭 기간 ma_120 NaN% 가 1-5% 유지 (이전 100% 재발 안 함)

## Test plan
- [x] since 값 200 → 400 변경 확인
- [ ] PR 머지 후 `build_stock_indicators.py` 전체 재계산 한 번 실행 (갭 메움)
- [ ] 그 다음 `--monthly` 실행 후 audit 으로 갭 재발 안 하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)