### PR TITLE
fix: 레짐 조합 저장 전략을 비교 chip으로 못 가져오던 문제

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -681,7 +681,7 @@ def api_get_strategy(name: str, universe: Optional[str] = None, rebal_type: Opti
         ]
     for u, r in combos:
         data = load_strategy(name, rebal_type=r, universe=u)
-        if data and data.get("code"):
+        if data and (data.get("code") or data.get("results")):
             return _convert_for_json(data)
     raise HTTPException(status_code=404, detail="전략을 찾을 수 없습니다.")
 

--- a/frontend/src/app/lab/page.tsx
+++ b/frontend/src/app/lab/page.tsx
@@ -298,13 +298,15 @@ export default function LabPage() {
         try {
           const data = await getStrategy(name, universe, rebalType);
           const r = (data?.results ?? {}) as Record<string, unknown>;
-          // results_json may be a StrategyResult directly, or wrap a CUSTOM key
+          // results_json may be a StrategyResult directly, or wrap a CUSTOM / REGIME_COMBO key
           if (r && typeof r === 'object' && 'rebalance_dates' in r) {
             return [name, r as unknown as StrategyResult] as const;
           }
-          const custom = r['CUSTOM'] as Record<string, unknown> | undefined;
-          if (custom && 'rebalance_dates' in custom) {
-            return [name, custom as unknown as StrategyResult] as const;
+          for (const key of ['CUSTOM', 'REGIME_COMBO']) {
+            const inner = r[key] as Record<string, unknown> | undefined;
+            if (inner && 'rebalance_dates' in inner) {
+              return [name, inner as unknown as StrategyResult] as const;
+            }
           }
           return null;
         } catch {


### PR DESCRIPTION
## Summary
- 백엔드 `/api/strategies/{name}`이 `code` 비면 404 거부 → 레짐 조합 저장은 `code=''`라 fetch 실패. `code or results` 둘 중 하나만 있어도 반환하도록 완화
- 프론트 비교 chip fetch 로직이 `rebalance_dates` / `CUSTOM` 키만 보던 걸 `REGIME_COMBO` 키도 함께 탐색하도록 수정

## Test plan
- [ ] 레짐 조합 전략 저장 후 전략실험실 비교 화면에서 chip으로 추가되는지 확인
- [ ] 기존 일반/커스텀 전략 chip 동작 회귀 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)