### PR TITLE
fix: 레짐 조합 탭에서 MA/Inertia 기준 버튼 숨김

### DIFF
--- a/frontend/src/app/lab/page.tsx
+++ b/frontend/src/app/lab/page.tsx
@@ -227,7 +227,7 @@ export default function LabPage() {
   const [regimeSaveMsg, setRegimeSaveMsg] = useState('');
   const [regimeMaWindow, setRegimeMaWindow] = useState(50);
   const [regimeMaWindowInput, setRegimeMaWindowInput] = useState('50');
-  const [regimeMode, setRegimeMode] = useState<'ma' | 'cycle' | 'ai' | 'inertia'>('ma');
+  const [regimeMode, setRegimeMode] = useState<'ma' | 'cycle' | 'ai' | 'inertia'>('cycle');
 
   // ─── Auto-generate strategy name ───
   const autoName = useMemo(() => {
@@ -1203,10 +1203,6 @@ export default function LabPage() {
                   <span className="text-xs text-muted font-medium">레짐 기준</span>
                   <div className="flex rounded-lg border border-border overflow-hidden text-xs">
                     <button
-                      onClick={() => setRegimeMode('ma')}
-                      className={`px-3 py-1.5 transition-colors ${regimeMode === 'ma' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
-                    >MA 기준</button>
-                    <button
                       onClick={() => setRegimeMode('cycle')}
                       className={`px-3 py-1.5 transition-colors ${regimeMode === 'cycle' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
                     >사이클 기준</button>
@@ -1214,10 +1210,6 @@ export default function LabPage() {
                       onClick={() => setRegimeMode('ai')}
                       className={`px-3 py-1.5 transition-colors ${regimeMode === 'ai' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
                     >AI 기준</button>
-                    <button
-                      onClick={() => setRegimeMode('inertia')}
-                      className={`px-3 py-1.5 transition-colors ${regimeMode === 'inertia' ? 'bg-primary text-white' : 'bg-surface text-muted hover:text-foreground'}`}
-                    >Inertia 기준</button>
                   </div>
                 </div>
                 {regimeMode === 'ma' && (


### PR DESCRIPTION
## Summary
- 레짐 조합 탭의 '레짐 기준' 버튼 4개 중 MA·Inertia 두 개 숨김 (사이클·AI만 노출)
- 기본 모드를 `'ma'` → `'cycle'`로 변경
- 조건부 렌더링 블록과 백엔드 `regime_mode` 분기는 그대로 두어 archive 상태 (코드 복구 시 버튼만 다시 끼우면 됨)

## Test plan
- [ ] /lab 페이지 → 레짐 조합 탭 진입 시 '사이클 기준' 버튼이 기본 선택돼야 함
- [ ] 버튼 행에 '사이클 기준', 'AI 기준' 두 개만 보여야 함
- [ ] 사이클·AI 모드 각각 실행해 백테스트 결과가 정상 표시되는지 확인
- [ ] Railway 자동 배포 후 운영 웹뷰에서도 동일하게 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)